### PR TITLE
Add Application.Read.All permission to setupauth.md

### DIFF
--- a/docs/using-the-assessment-tool/setupauth.md
+++ b/docs/using-the-assessment-tool/setupauth.md
@@ -43,9 +43,9 @@ The Microsoft 365 Assessment tool aims to be able to perform the assessment task
 Register-PnPAzureADApp -ApplicationName Microsoft365AssessmentToolForAlerts `
                        -Tenant contoso.onmicrosoft.com `
                        -Store CurrentUser `
-                       -GraphApplicationPermissions "Sites.Read.All" `
+                       -GraphApplicationPermissions "Sites.Read.All", "Application.Read.All" `
                        -SharePointApplicationPermissions "Sites.FullControl.All" `
-                       -GraphDelegatePermissions "Sites.Read.All", "User.Read" `
+                       -GraphDelegatePermissions "Sites.Read.All", "User.Read", "Application.Read.All" `
                        -SharePointDelegatePermissions "AllSites.FullControl" `
                        -Username "joe@contoso.onmicrosoft.com" `
                        -Interactive


### PR DESCRIPTION
I just had an issue starting an AddIns ACS assessment. I found the closed issue `Assessment job not started due to error: Microsoft Graph service exception #47`  with the resolution. I've updated the docs to include this resolution. Hopefully the next user won't encounter this