### PR TITLE
Classic page scan (T2): add page-scan CLI option flags

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/ClassicOptionsTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/ClassicOptionsTests.cs
@@ -1,0 +1,104 @@
+﻿using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using PnP.Scanning.Core.Services;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners
+{
+    /// <summary>
+    /// T2 — verifies the new Classic page-scan option flags plumb through cleanly:
+    /// gRPC <see cref="StartRequest"/> properties → <see cref="OptionsBase.FromScannerInput"/> →
+    /// <see cref="ClassicOptions"/>, and that the CLI write-side
+    /// (<see cref="ClassicStartRequestBuilder"/>) emits exactly the keys the read-side consumes.
+    /// </summary>
+    public class ClassicOptionsTests
+    {
+        // (property key, flag name) — the flag name selects which ClassicOptions property to read.
+        // A string identifier is used (rather than a Func<ClassicOptions, bool>) because
+        // ClassicOptions is internal and cannot appear in a public xUnit theory signature.
+        public static IEnumerable<object[]> FlagCases()
+        {
+            yield return new object[] { Constants.StartClassicExportWebPartProperties, nameof(ClassicOptions.ExportWebPartProperties) };
+            yield return new object[] { Constants.StartClassicSkipUsageInformation, nameof(ClassicOptions.SkipUsageInformation) };
+            yield return new object[] { Constants.StartClassicSkipUserInformation, nameof(ClassicOptions.SkipUserInformation) };
+            yield return new object[] { Constants.StartClassicHomePageOnly, nameof(ClassicOptions.HomePageOnly) };
+        }
+
+        [Theory]
+        [MemberData(nameof(FlagCases))]
+        public void Options_FromScannerInput_MapsFlags(string propertyKey, string flagName)
+        {
+            // Property present and "True" → flag set.
+            var whenTrue = (ClassicOptions)OptionsBase.FromScannerInput(ClassicRequest((propertyKey, bool.TrueString)));
+            ReadFlag(whenTrue, flagName).Should().BeTrue();
+
+            // Property present and "False" → flag explicitly cleared.
+            var whenFalse = (ClassicOptions)OptionsBase.FromScannerInput(ClassicRequest((propertyKey, bool.FalseString)));
+            ReadFlag(whenFalse, flagName).Should().BeFalse();
+        }
+
+        private static bool ReadFlag(ClassicOptions options, string flagName) => flagName switch
+        {
+            nameof(ClassicOptions.ExportWebPartProperties) => options.ExportWebPartProperties,
+            nameof(ClassicOptions.SkipUsageInformation) => options.SkipUsageInformation,
+            nameof(ClassicOptions.SkipUserInformation) => options.SkipUserInformation,
+            nameof(ClassicOptions.HomePageOnly) => options.HomePageOnly,
+            _ => throw new ArgumentOutOfRangeException(nameof(flagName), flagName, "Unknown flag"),
+        };
+
+        [Fact]
+        public void Options_FromScannerInput_FlagsDefaultFalse_WhenAbsent()
+        {
+            // No page-scan flag properties at all → every flag defaults to false.
+            var options = (ClassicOptions)OptionsBase.FromScannerInput(ClassicRequest());
+
+            options.ExportWebPartProperties.Should().BeFalse();
+            options.SkipUsageInformation.Should().BeFalse();
+            options.SkipUserInformation.Should().BeFalse();
+            options.HomePageOnly.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Options_RoundTrip_CliToProperties()
+        {
+            // Build the gRPC request exactly as the CLI handler does, then read it back: this
+            // proves the keys the write-side emits match the keys FromScannerInput consumes.
+            var request = new StartRequest { Mode = Mode.Classic.ToString() };
+
+            ClassicStartRequestBuilder.AddClassicProperties(
+                request,
+                new[] { ClassicComponent.Pages },
+                exportWebPartProperties: true,
+                skipUsageInformation: true,
+                skipUserInformation: false,
+                homePageOnly: true);
+
+            var options = (ClassicOptions)OptionsBase.FromScannerInput(request);
+
+            // Scan component still round-trips...
+            options.Pages.Should().BeTrue();
+
+            // ...and the new flags arrive with the values the CLI supplied.
+            options.ExportWebPartProperties.Should().BeTrue();
+            options.SkipUsageInformation.Should().BeTrue();
+            options.SkipUserInformation.Should().BeFalse();
+            options.HomePageOnly.Should().BeTrue();
+        }
+
+        private static StartRequest ClassicRequest(params (string Key, string Value)[] properties)
+        {
+            var request = new StartRequest { Mode = Mode.Classic.ToString() };
+            foreach (var (key, value) in properties)
+            {
+                request.Properties.Add(new PropertyRequest
+                {
+                    Property = key,
+                    Type = "bool",
+                    Value = value,
+                });
+            }
+
+            return request;
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Constants.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Constants.cs
@@ -19,6 +19,10 @@
         internal const string StartSyntexFull = "syntexfull";
         internal const string StartWorkflowAnalyze = "workflowanalyze";
         internal const string StartClassicInclude = "classicinclude";
+        internal const string StartClassicExportWebPartProperties = "exportwebpartproperties";
+        internal const string StartClassicSkipUsageInformation = "skipusageinformation";
+        internal const string StartClassicSkipUserInformation = "skipuserinformation";
+        internal const string StartClassicHomePageOnly = "homepageonly";
         internal const string StartTestNumberOfSites = "testnumberofsites";
 
         internal const string ListRunning = "running";

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/ClassicOptions.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/ClassicOptions.cs
@@ -15,5 +15,20 @@
         internal bool Lists { get; set; }
 
         internal bool Extensibility { get; set; }
+
+        // Page-scan flags (see classic-page-scan merge plan §7). Additive; consumed by the
+        // page scan path (T5/T10/T13). Defaults below are the no-flag behavior.
+
+        /// <summary>Persist classic web part properties (JSON) when assessing pages.</summary>
+        internal bool ExportWebPartProperties { get; set; }
+
+        /// <summary>Skip the search-based page usage statistics (recent/lifetime views).</summary>
+        internal bool SkipUsageInformation { get; set; }
+
+        /// <summary>Skip user information lookups (e.g. page ModifiedBy).</summary>
+        internal bool SkipUserInformation { get; set; }
+
+        /// <summary>Only assess the home page of each web.</summary>
+        internal bool HomePageOnly { get; set; }
     }
 }

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/ClassicStartRequestBuilder.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/ClassicStartRequestBuilder.cs
@@ -1,0 +1,52 @@
+﻿using PnP.Scanning.Core.Services;
+
+namespace PnP.Scanning.Core.Scanners
+{
+    /// <summary>
+    /// Builds the gRPC <see cref="StartRequest"/> properties for a Classic assessment from the CLI
+    /// option values. This is the write-side counterpart of
+    /// <see cref="OptionsBase.FromScannerInput(StartRequest)"/>: both sides agree on the property
+    /// keys (the <see cref="ClassicComponent"/> enum names plus the Classic flag constants) so the
+    /// CLI options round-trip cleanly into <see cref="ClassicOptions"/>. Keeping this as a pure,
+    /// dependency-free method lets the CLI → properties → options round-trip be unit-tested without
+    /// the gRPC host.
+    /// </summary>
+    internal static class ClassicStartRequestBuilder
+    {
+        internal static void AddClassicProperties(
+            StartRequest request,
+            IEnumerable<ClassicComponent> components,
+            bool exportWebPartProperties,
+            bool skipUsageInformation,
+            bool skipUserInformation,
+            bool homePageOnly)
+        {
+            // Each requested scan component is keyed by its enum name and is always "on" (true);
+            // FromScannerInput reads these as the set of enabled ClassicComponents.
+            foreach (var classicComponent in components)
+            {
+                request.Properties.Add(new PropertyRequest
+                {
+                    Property = $"{classicComponent}",
+                    Type = "bool",
+                    Value = true.ToString(),
+                });
+            }
+
+            AddBool(request, Constants.StartClassicExportWebPartProperties, exportWebPartProperties);
+            AddBool(request, Constants.StartClassicSkipUsageInformation, skipUsageInformation);
+            AddBool(request, Constants.StartClassicSkipUserInformation, skipUserInformation);
+            AddBool(request, Constants.StartClassicHomePageOnly, homePageOnly);
+        }
+
+        private static void AddBool(StartRequest request, string property, bool value)
+        {
+            request.Properties.Add(new PropertyRequest
+            {
+                Property = property,
+                Type = "bool",
+                Value = value.ToString(),
+            });
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/OptionsBase.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/OptionsBase.cs
@@ -64,6 +64,22 @@ namespace PnP.Scanning.Core.Scanners
                     {
                         (options as ClassicOptions).Extensibility = bool.Parse(property.Value);
                     }
+                    else if (property.Property == Constants.StartClassicExportWebPartProperties)
+                    {
+                        (options as ClassicOptions).ExportWebPartProperties = bool.Parse(property.Value);
+                    }
+                    else if (property.Property == Constants.StartClassicSkipUsageInformation)
+                    {
+                        (options as ClassicOptions).SkipUsageInformation = bool.Parse(property.Value);
+                    }
+                    else if (property.Property == Constants.StartClassicSkipUserInformation)
+                    {
+                        (options as ClassicOptions).SkipUserInformation = bool.Parse(property.Value);
+                    }
+                    else if (property.Property == Constants.StartClassicHomePageOnly)
+                    {
+                        (options as ClassicOptions).HomePageOnly = bool.Parse(property.Value);
+                    }
                 }
             }
 #if DEBUG

--- a/src/PnP.Scanning/PnP.Scanning.Process/Commands/Handlers/StartCommandHandler.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Process/Commands/Handlers/StartCommandHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.DataProtection;
 using PnP.Core.Services;
 using PnP.Scanning.Core;
 using PnP.Scanning.Core.Authentication;
+using PnP.Scanning.Core.Scanners;
 using PnP.Scanning.Core.Services;
 using PnP.Scanning.Process.Services;
 using Spectre.Console;
@@ -34,6 +35,10 @@ namespace PnP.Scanning.Process.Commands
         private Option<bool> syntexFullOption;
         private Option<bool> workflowAnalyzeOption;
         private Option<List<ClassicComponent>> classicIncludeOption;
+        private Option<bool> classicExportWebPartPropertiesOption;
+        private Option<bool> classicSkipUsageInformationOption;
+        private Option<bool> classicSkipUserInformationOption;
+        private Option<bool> classicHomePageOnlyOption;
 
 #if DEBUG
         // Specific options for the test handler
@@ -258,13 +263,36 @@ namespace PnP.Scanning.Process.Commands
 
             classicIncludeOption = new(name: $"--{Constants.StartClassicInclude}",
                 //getDefaultValue: () => null,
-                description: "Included classic scan components")                
+                description: "Included classic scan components")
             {
                 IsRequired = false,
                 AllowMultipleArgumentsPerToken = true,
                 Arity = ArgumentArity.ZeroOrMore
             };
             cmd.AddOption(classicIncludeOption);
+
+            // These page-scan flags only make sense for a Classic assessment, so they are rejected
+            // for any other --mode (mirrors the --testnumberofsites mode guard). They are also only
+            // consumed when --mode classic (see HandleStartAsync).
+            classicExportWebPartPropertiesOption = CreateClassicFlagOption(
+                Constants.StartClassicExportWebPartProperties,
+                "Export classic web part properties (JSON) during classic page assessment");
+            cmd.AddOption(classicExportWebPartPropertiesOption);
+
+            classicSkipUsageInformationOption = CreateClassicFlagOption(
+                Constants.StartClassicSkipUsageInformation,
+                "Skip collecting classic page usage information (recent/lifetime views)");
+            cmd.AddOption(classicSkipUsageInformationOption);
+
+            classicSkipUserInformationOption = CreateClassicFlagOption(
+                Constants.StartClassicSkipUserInformation,
+                "Skip collecting classic page user information (e.g. ModifiedBy)");
+            cmd.AddOption(classicSkipUserInformationOption);
+
+            classicHomePageOnlyOption = CreateClassicFlagOption(
+                Constants.StartClassicHomePageOnly,
+                "Only assess the home page of each web during classic page assessment");
+            cmd.AddOption(classicHomePageOnlyOption);
 #if DEBUG
             testNumberOfSitesOption = new(
                 name: $"--{Constants.StartTestNumberOfSites}",
@@ -300,6 +328,47 @@ namespace PnP.Scanning.Process.Commands
         }
 
         /// <summary>
+        /// Creates a boolean page-scan option that is only valid for a Classic assessment. When the
+        /// flag is supplied together with any other --mode the parse fails with a clear error,
+        /// mirroring the --testnumberofsites mode guard. Supports both switch usage (--flag) and an
+        /// explicit --flag true/false value.
+        /// </summary>
+        private Option<bool> CreateClassicFlagOption(string name, string description)
+        {
+            var option = new Option<bool>(
+                name: $"--{name}",
+                parseArgument: (result) =>
+                {
+                    var mode = result.FindResultFor(modeOption);
+                    if (mode != null && mode.GetValueOrDefault<Mode>() != Mode.Classic)
+                    {
+                        result.ErrorMessage = $"--{name} can only be used with --{Constants.StartMode} classic";
+                        return false;
+                    }
+
+                    if (result.Tokens.Count == 0)
+                    {
+                        // Switch style: "--flag" with no value means true.
+                        return true;
+                    }
+
+                    if (!bool.TryParse(result.Tokens[0].Value, out var value))
+                    {
+                        result.ErrorMessage = $"--{name} requires a true or false value";
+                        return false;
+                    }
+
+                    return value;
+                },
+                description: description)
+            {
+                IsRequired = false
+            };
+            option.SetDefaultValue(false);
+            return option;
+        }
+
+        /// <summary>
         /// https://github.com/dotnet/command-line-api/blob/main/docs/model-binding.md#more-complex-types
         /// </summary>
         /// <returns></returns>
@@ -312,6 +381,10 @@ namespace PnP.Scanning.Process.Commands
                                               , syntexFullOption
                                               , workflowAnalyzeOption
                                               , classicIncludeOption
+                                              , classicExportWebPartPropertiesOption
+                                              , classicSkipUsageInformationOption
+                                              , classicSkipUserInformationOption
+                                              , classicHomePageOnlyOption
 #if DEBUG
                                               , testNumberOfSitesOption
 #endif
@@ -454,15 +527,13 @@ namespace PnP.Scanning.Process.Commands
                         classicComponents = Enum.GetValues(typeof(ClassicComponent)).Cast<ClassicComponent>().ToList();
                     }
 
-                    foreach (var classicComponent in classicComponents)
-                    {
-                        start.Properties.Add(new PropertyRequest
-                        {
-                            Property = $"{classicComponent}",
-                            Type = "bool",
-                            Value = true.ToString(),
-                        });
-                    }
+                    ClassicStartRequestBuilder.AddClassicProperties(
+                        start,
+                        classicComponents,
+                        arguments.ExportWebPartProperties,
+                        arguments.SkipUsageInformation,
+                        arguments.SkipUserInformation,
+                        arguments.HomePageOnly);
                 }
 
 #if DEBUG

--- a/src/PnP.Scanning/PnP.Scanning.Process/Commands/Options/StartBinder.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Process/Commands/Options/StartBinder.cs
@@ -23,6 +23,10 @@ namespace PnP.Scanning.Process.Commands
         private readonly Option<bool> syntexDeepScan;
         private readonly Option<bool> workflowAnalyze;
         private readonly Option<List<ClassicComponent>> classicIncludeOption;
+        private readonly Option<bool> classicExportWebPartProperties;
+        private readonly Option<bool> classicSkipUsageInformation;
+        private readonly Option<bool> classicSkipUserInformation;
+        private readonly Option<bool> classicHomePageOnly;
 #if DEBUG
         private readonly Option<int> testNumberOfSites;
 #endif
@@ -33,6 +37,10 @@ namespace PnP.Scanning.Process.Commands
                            , Option<bool> syntexDeepScanInput
                            , Option<bool> workflowAnalyzeInput
                            , Option<List<ClassicComponent>> classicIncludeOptionInput
+                           , Option<bool> classicExportWebPartPropertiesInput
+                           , Option<bool> classicSkipUsageInformationInput
+                           , Option<bool> classicSkipUserInformationInput
+                           , Option<bool> classicHomePageOnlyInput
 #if DEBUG
                            , Option<int> testNumberOfSitesInput
 #endif
@@ -54,6 +62,10 @@ namespace PnP.Scanning.Process.Commands
             syntexDeepScan = syntexDeepScanInput;
             workflowAnalyze = workflowAnalyzeInput;
             classicIncludeOption = classicIncludeOptionInput;
+            classicExportWebPartProperties = classicExportWebPartPropertiesInput;
+            classicSkipUsageInformation = classicSkipUsageInformationInput;
+            classicSkipUserInformation = classicSkipUserInformationInput;
+            classicHomePageOnly = classicHomePageOnlyInput;
 #if DEBUG
             testNumberOfSites = testNumberOfSitesInput;
 #endif
@@ -77,6 +89,10 @@ namespace PnP.Scanning.Process.Commands
                 SyntexDeepScan = bindingContext.ParseResult.GetValueForOption(syntexDeepScan),
                 WorkflowAnalyze = bindingContext.ParseResult.GetValueForOption(workflowAnalyze),
                 ClassicInclude = bindingContext.ParseResult.GetValueForOption(classicIncludeOption),
+                ExportWebPartProperties = bindingContext.ParseResult.GetValueForOption(classicExportWebPartProperties),
+                SkipUsageInformation = bindingContext.ParseResult.GetValueForOption(classicSkipUsageInformation),
+                SkipUserInformation = bindingContext.ParseResult.GetValueForOption(classicSkipUserInformation),
+                HomePageOnly = bindingContext.ParseResult.GetValueForOption(classicHomePageOnly),
 
 #if DEBUG
                 TestNumberOfSites = bindingContext.ParseResult.GetValueForOption(testNumberOfSites),

--- a/src/PnP.Scanning/PnP.Scanning.Process/Commands/Options/StartOptions.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Process/Commands/Options/StartOptions.cs
@@ -34,6 +34,14 @@ namespace PnP.Scanning.Process.Commands
 
         public List<ClassicComponent> ClassicInclude { get; set; }
 
+        public bool ExportWebPartProperties { get; set; }
+
+        public bool SkipUsageInformation { get; set; }
+
+        public bool SkipUserInformation { get; set; }
+
+        public bool HomePageOnly { get; set; }
+
 #if DEBUG
         public int TestNumberOfSites { get; set; }
 #endif


### PR DESCRIPTION
## Summary

Implements **T2 — Options plumbing** from the classic page-scan backlog. Adds the four classic
page-scan option flags carried over from the legacy SharePoint Modernization Scanner and plumbs
them end-to-end through the assessment pipeline:

**CLI option → `StartRequest.Properties` (gRPC) → `OptionsBase.FromScannerInput` → `ClassicOptions`**

No scan behavior changes yet — consumers read these options in later tasks (T3/T5/T10/T13). This PR
is additive plumbing plus its unit tests.

## New CLI flags (Classic mode only)

| Flag | Maps to | Legacy origin |
|---|---|---|
| `--exportwebpartproperties` | `ClassicOptions.ExportWebPartProperties` | old `-b` |
| `--skipusageinformation` | `ClassicOptions.SkipUsageInformation` | old `-c` |
| `--skipuserinformation` | `ClassicOptions.SkipUserInformation` | old `-j` |
| `--homepageonly` | `ClassicOptions.HomePageOnly` | old `Mode.HomePageOnly` (remodeled mode → flag) |

All four default to `false`, support both switch style (`--flag`) and explicit `--flag true|false`,
and are **rejected at parse time for any non-Classic `--mode`** (mirrors the `--testnumberofsites`
guard).

## Changes

**`PnP.Scanning.Core`**
- `Constants.cs` — four shared property-key constants for the new flags.
- `Scanners/Classic/ClassicOptions.cs` — four new `bool` properties.
- `Scanners/OptionsBase.cs` — parse the new keys in the Classic branch of `FromScannerInput`.
- `Scanners/Classic/ClassicStartRequestBuilder.cs` *(new)* — pure write-side helper that builds the
  classic `StartRequest` properties (the inverse of `FromScannerInput`). This is the testable seam
  shared by the CLI handler and the round-trip test.

**`PnP.Scanning.Process`**
- `Commands/Options/StartOptions.cs` / `StartBinder.cs` — bind the four new options.
- `Commands/Handlers/StartCommandHandler.cs` — define the four options via a new
  `CreateClassicFlagOption` helper (mode-guarded), and replace the inline classic property loop with
  a call to `ClassicStartRequestBuilder.AddClassicProperties(...)`.

**`PnP.Scanning.Core.Tests`**
- `Scanners/ClassicOptionsTests.cs` *(new)* — 6 tests.

## Testing

- `Options_FromScannerInput_MapsFlags` `[Theory]` — each flag: `true` sets / `false` clears.
- `Options_FromScannerInput_FlagsDefaultFalse_WhenAbsent` — defaults asserted when keys absent.
- `Options_RoundTrip_CliToProperties` — builds the request exactly as the CLI handler does, reads it
  back through `FromScannerInput`; proves emitted keys match consumed keys.
- Full suite green: **10/10** (T0:1, T1:3, T2:6). All projects build with 0 warnings / 0 errors.
- CLI parse guard verified by running `microsoft365-assessment.exe`:
  `--mode Workflow --exportwebpartproperties` → rejected; `--mode Classic --exportwebpartproperties`
  → accepted.

## Notes

- The parse-level mode guard, like the existing `--testnumberofsites` guard, is not unit-tested
  (the Core test project doesn't reference the `Process` CLI assembly); it's verified by running the
  CLI. The flag → property → options round-trip *is* unit-tested.
- New source files saved as UTF-8 with BOM + CRLF per repo convention.