### PR TITLE
Classic page scan — Delve blog page typing + ModifiedBy capture

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/PageScanComponentTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/PageScanComponentTests.cs
@@ -72,22 +72,23 @@ namespace PnP.Scanning.Core.Tests.Scanners
         }
 
         [Fact]
-        public void ModifiedBy_EditorField_ParsesDisplayName()
+        public void ModifiedBy_EditorField_ReturnsEmail()
         {
+            // Parity with legacy LastModifiedBy: the account email wins when present.
             var fields = new Dictionary<string, object>
             {
-                { ModifiedByField, new FakeUserValue(lookupValue: "Jane Doe") },
+                { ModifiedByField, new FakeUserValue(email: "jane.doe@contoso.com", lookupValue: "Jane Doe") },
             };
 
-            PageScanComponent.GetModifiedBy(fields, skipUserInformation: false).Should().Be("Jane Doe");
+            PageScanComponent.GetModifiedBy(fields, skipUserInformation: false).Should().Be("jane.doe@contoso.com");
         }
 
         [Fact]
-        public void ModifiedBy_EditorField_FallsBackToTitle_WhenLookupValueEmpty()
+        public void ModifiedBy_EditorField_FallsBackToLookupValue_WhenEmailEmpty()
         {
             var fields = new Dictionary<string, object>
             {
-                { ModifiedByField, new FakeUserValue(lookupValue: "", title: "John Smith") },
+                { ModifiedByField, new FakeUserValue(email: "", lookupValue: "John Smith") },
             };
 
             PageScanComponent.GetModifiedBy(fields, skipUserInformation: false).Should().Be("John Smith");
@@ -98,7 +99,7 @@ namespace PnP.Scanning.Core.Tests.Scanners
         {
             var fields = new Dictionary<string, object>
             {
-                { ModifiedByField, new FakeUserValue(lookupValue: "Jane Doe") },
+                { ModifiedByField, new FakeUserValue(email: "jane.doe@contoso.com", lookupValue: "Jane Doe") },
             };
 
             PageScanComponent.GetModifiedBy(fields, skipUserInformation: true).Should().BeNull();
@@ -116,8 +117,9 @@ namespace PnP.Scanning.Core.Tests.Scanners
         /// </summary>
         private sealed class FakeUserValue : IFieldUserValue
         {
-            public FakeUserValue(string lookupValue, string title = null)
+            public FakeUserValue(string email = null, string lookupValue = null, string title = null)
             {
+                Email = email;
                 LookupValue = lookupValue;
                 Title = title;
             }
@@ -134,7 +136,7 @@ namespace PnP.Scanning.Core.Tests.Scanners
 
             public ISharePointPrincipal Principal { get; set; }
 
-            public string Email => null;
+            public string Email { get; }
 
             public string Sip => null;
 

--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/PageScanComponentTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/PageScanComponentTests.cs
@@ -1,0 +1,144 @@
+﻿using FluentAssertions;
+using PnP.Core.Model.Security;
+using PnP.Core.Model.SharePoint;
+using PnP.Scanning.Core.Scanners;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners
+{
+    /// <summary>
+    /// T3 — quick-win metadata fixes: Delve blog page typing and the page "Modified By" capture.
+    /// Both helpers are pure functions over the raw list-item field values (no CSOM), so they are
+    /// exercised here directly with fake field dictionaries.
+    /// </summary>
+    public class PageScanComponentTests
+    {
+        // SharePoint internal field names (mirrors the private constants in PageScanComponent).
+        private const string FileTypeField = "File_x0020_Type";
+        private const string HtmlFileTypeField = "HTML_x0020_File_x0020_Type";
+        private const string WikiField = "WikiField";
+        private const string BSNField = "BSN";
+        private const string ModifiedByField = "Editor";
+
+        [Fact]
+        public void GetPageType_DelveBlogItem_ReturnsDelveBlog()
+        {
+            // A Delve blog page surfaces with the "pointpub" file type and no wiki/web part markers.
+            var fields = new Dictionary<string, object>
+            {
+                { FileTypeField, "pointpub" },
+            };
+
+            PageScanComponent.GetPageType(fields).Should().Be(PageScanComponent.DelveBlogPage);
+        }
+
+        [Fact]
+        public void GetPageType_DelveBlogFileType_IsCaseInsensitive()
+        {
+            var fields = new Dictionary<string, object>
+            {
+                { FileTypeField, "PointPub" },
+            };
+
+            PageScanComponent.GetPageType(fields).Should().Be(PageScanComponent.DelveBlogPage);
+        }
+
+        [Fact]
+        public void GetPageType_NonDelveItem_DoesNotReturnDelveBlog()
+        {
+            // Control 1: a classic web part page is still typed as a web part page.
+            var webPartPage = new Dictionary<string, object>
+            {
+                { HtmlFileTypeField, "SharePoint.WebPartPage.Document" },
+                { FileTypeField, "aspx" },
+            };
+            PageScanComponent.GetPageType(webPartPage).Should().Be(PageScanComponent.WebPartPage);
+
+            // Control 2: a plain aspx page (no pointpub marker) is never classified as Delve.
+            var aspxPage = new Dictionary<string, object>
+            {
+                { FileTypeField, "aspx" },
+                { BSNField, "1" },
+            };
+            PageScanComponent.GetPageType(aspxPage).Should().NotBe(PageScanComponent.DelveBlogPage);
+
+            // Control 3: a wiki page (WikiField present) wins before the Delve check.
+            var wikiPage = new Dictionary<string, object>
+            {
+                { WikiField, "<div></div>" },
+                { FileTypeField, "pointpub" },
+            };
+            PageScanComponent.GetPageType(wikiPage).Should().Be(PageScanComponent.WikiPage);
+        }
+
+        [Fact]
+        public void ModifiedBy_EditorField_ParsesDisplayName()
+        {
+            var fields = new Dictionary<string, object>
+            {
+                { ModifiedByField, new FakeUserValue(lookupValue: "Jane Doe") },
+            };
+
+            PageScanComponent.GetModifiedBy(fields, skipUserInformation: false).Should().Be("Jane Doe");
+        }
+
+        [Fact]
+        public void ModifiedBy_EditorField_FallsBackToTitle_WhenLookupValueEmpty()
+        {
+            var fields = new Dictionary<string, object>
+            {
+                { ModifiedByField, new FakeUserValue(lookupValue: "", title: "John Smith") },
+            };
+
+            PageScanComponent.GetModifiedBy(fields, skipUserInformation: false).Should().Be("John Smith");
+        }
+
+        [Fact]
+        public void ModifiedBy_SkipUserInformation_IsNull()
+        {
+            var fields = new Dictionary<string, object>
+            {
+                { ModifiedByField, new FakeUserValue(lookupValue: "Jane Doe") },
+            };
+
+            PageScanComponent.GetModifiedBy(fields, skipUserInformation: true).Should().BeNull();
+        }
+
+        [Fact]
+        public void ModifiedBy_NoEditorField_IsNull()
+        {
+            PageScanComponent.GetModifiedBy(new Dictionary<string, object>(), skipUserInformation: false).Should().BeNull();
+        }
+
+        /// <summary>
+        /// Minimal stand-in for the user value a list-item user field exposes. Only the members the
+        /// ModifiedBy parser reads (LookupValue, Title) are meaningful; the rest satisfy the interface.
+        /// </summary>
+        private sealed class FakeUserValue : IFieldUserValue
+        {
+            public FakeUserValue(string lookupValue, string title = null)
+            {
+                LookupValue = lookupValue;
+                Title = title;
+            }
+
+            public string LookupValue { get; }
+
+            public string Title { get; }
+
+            public IField Field => null;
+
+            public int LookupId { get; set; }
+
+            public bool IsSecretFieldValue => false;
+
+            public ISharePointPrincipal Principal { get; set; }
+
+            public string Email => null;
+
+            public string Sip => null;
+
+            public string Picture => null;
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
@@ -359,7 +359,9 @@ namespace PnP.Scanning.Core.Scanners
             }
         }
 
-        // Pure extraction of the page "Modified By" display name (no CSOM) so it is unit-testable.
+        // Pure extraction of the page "Modified By" (no CSOM) so it is unit-testable.
+        // Parity with the legacy scanner's ListItemExtensions.LastModifiedBy: prefer the account
+        // email, falling back to the lookup display value when no email is present.
         internal static string GetModifiedBy(IDictionary<string, object> fieldValues, bool skipUserInformation)
         {
             if (skipUserInformation)
@@ -369,8 +371,7 @@ namespace PnP.Scanning.Core.Scanners
 
             if (fieldValues.TryGetValue(ModifiedByField, out object value) && value is IFieldUserValue user)
             {
-                // For user fields loaded via list data stream the display name lands in LookupValue (and Title).
-                return !string.IsNullOrEmpty(user.LookupValue) ? user.LookupValue : user.Title;
+                return !string.IsNullOrEmpty(user.Email) ? user.Email : user.LookupValue;
             }
 
             return null;

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
@@ -20,6 +20,7 @@ namespace PnP.Scanning.Core.Scanners
         private const string ContentTypeIdField = "ContentTypeId";
         private const string WikiField = "WikiField";
         private const string ModifiedField = "Modified";
+        private const string ModifiedByField = "Editor";
         private const string CreatedField = "Created";
         private const string ClientSideApplicationIdField = "ClientSideApplicationId";
         private const string TitleField = "Title";
@@ -32,6 +33,10 @@ namespace PnP.Scanning.Core.Scanners
         internal const string ASPXPage = "ASPXPage";
         internal const string PublishingPage = "PublishingPage";
         internal const string BlogPage = "BlogPage";
+        internal const string DelveBlogPage = "DelveBlogPage";
+
+        // File type value identifying a Delve blog page (point publishing)
+        private const string DelveBlogFileType = "pointpub";
 
         internal static async Task ExecuteAsync(ScannerBase scannerBase, PnPContext context, ClientContext csomContext)
         {
@@ -39,6 +44,9 @@ namespace PnP.Scanning.Core.Scanners
             List<ClassicPage> pagesList = new();
             int modernPageCounter = 0;
             HashSet<string> remediationCodes = new();
+
+            // Page ModifiedBy is a user lookup; skip it when user information is not wanted.
+            bool skipUserInformation = ((ClassicScanner)scannerBase).Options.SkipUserInformation;
 
             var lists = ScannerBase.CleanLoadedLists(context);
 
@@ -67,6 +75,7 @@ namespace PnP.Scanning.Core.Scanners
                                 ListTitle = blogList.Title,
                                 ListId = blogList.Id,
                                 ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
+                                ModifiedBy = GetModifiedBy(listItem.Values, skipUserInformation),
                                 PageType = BlogPage,
                                 RemediationCode = RemediationCodes.CP4.ToString(),
                             });
@@ -80,14 +89,14 @@ namespace PnP.Scanning.Core.Scanners
                       scannerBase.WebTemplate == "SRCHCEN#0" || scannerBase.WebTemplate == "CMSPUBLISHING#0") &&
                      sitePublishingEnabled && webPublishingEnabled)
             {
-                await QueryPublishingPagesAsync(scannerBase, pagesList, lists, remediationCodes).ConfigureAwait(false);
+                await QueryPublishingPagesAsync(scannerBase, pagesList, lists, remediationCodes, skipUserInformation).ConfigureAwait(false);
             }
             else
             {
                 // A team site can also have the publishing features enabled
                 if (sitePublishingEnabled && webPublishingEnabled)
                 {
-                    await QueryPublishingPagesAsync(scannerBase, pagesList, lists, remediationCodes).ConfigureAwait(false);
+                    await QueryPublishingPagesAsync(scannerBase, pagesList, lists, remediationCodes, skipUserInformation).ConfigureAwait(false);
                 }
 
                 // Check for the regular pages library
@@ -112,6 +121,7 @@ namespace PnP.Scanning.Core.Scanners
                                     ListTitle = sitePagesLibrary.Title,
                                     ListId = sitePagesLibrary.Id,
                                     ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
+                                    ModifiedBy = GetModifiedBy(listItem.Values, skipUserInformation),
                                     PageType = GetPageType(listItem)
                                 };
 
@@ -183,7 +193,7 @@ namespace PnP.Scanning.Core.Scanners
                                                                    modernPageCounter, wikiPageCounter, blogPageCounter, webPartPageCounter, aspxPageCounter, publishingPageCounter);
         }
 
-        private static async Task QueryPublishingPagesAsync(ScannerBase scannerBase, List<ClassicPage> pagesList, List<IList> lists, HashSet<string> remediationCodes)
+        private static async Task QueryPublishingPagesAsync(ScannerBase scannerBase, List<ClassicPage> pagesList, List<IList> lists, HashSet<string> remediationCodes, bool skipUserInformation)
         {
             var pagesLibrary = lists.FirstOrDefault(l => l.TemplateType == PnP.Core.Model.SharePoint.ListTemplateType.PublishingPagesLibrary);
             if (pagesLibrary != null)
@@ -204,6 +214,7 @@ namespace PnP.Scanning.Core.Scanners
                             ListTitle = pagesLibrary.Title,
                             ListId = pagesLibrary.Id,
                             ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
+                            ModifiedBy = GetModifiedBy(listItem.Values, skipUserInformation),
                             PageType = PublishingPage,
                             RemediationCode = RemediationCodes.CP3.ToString(),
                         });
@@ -278,6 +289,7 @@ namespace PnP.Scanning.Core.Scanners
                     <FieldRef Name='{FileLeafRefField}' />
                     <FieldRef Name='{FileTypeField}' />
                     <FieldRef Name='{ModifiedField}' />
+                    <FieldRef Name='{ModifiedByField}' />
                     <FieldRef Name='{CreatedField}' />
                     <FieldRef Name='{TitleField}' />
                     <FieldRef Name='{BSNField}' />
@@ -296,9 +308,14 @@ namespace PnP.Scanning.Core.Scanners
 
         private static T GetFieldValue<T>(IListItem listItem, string fieldName, T defaultValue = default)
         {
-            if (listItem.Values.ContainsKey(fieldName) && listItem.Values[fieldName] != null)
+            return GetFieldValue(listItem.Values, fieldName, defaultValue);
+        }
+
+        private static T GetFieldValue<T>(IDictionary<string, object> fieldValues, string fieldName, T defaultValue = default)
+        {
+            if (fieldValues.ContainsKey(fieldName) && fieldValues[fieldName] != null)
             {
-                return (T)listItem.Values[fieldName];
+                return (T)fieldValues[fieldName];
             }
 
             return defaultValue;
@@ -306,22 +323,33 @@ namespace PnP.Scanning.Core.Scanners
 
         private static string GetPageType(IListItem listItem)
         {
-            if (GetFieldValue(listItem, HtmlFileTypeField, string.Empty) == "SharePoint.WebPartPage.Document")
+            return GetPageType(listItem.Values);
+        }
+
+        // Pure classification over the raw field values (no CSOM) so it is unit-testable.
+        internal static string GetPageType(IDictionary<string, object> fieldValues)
+        {
+            if (GetFieldValue(fieldValues, HtmlFileTypeField, string.Empty) == "SharePoint.WebPartPage.Document")
             {
                 return WebPartPage;
             }
 
-            if (GetFieldValue(listItem, ClientSideApplicationIdField, string.Empty).Equals($"{{{FeatureId_Web_ModernPage}}}", StringComparison.InvariantCultureIgnoreCase))
+            if (GetFieldValue(fieldValues, ClientSideApplicationIdField, string.Empty).Equals($"{{{FeatureId_Web_ModernPage}}}", StringComparison.InvariantCultureIgnoreCase))
             {
                 return ModernPage;
             }
 
-            if (GetFieldValue<string>(listItem, WikiField) != null)
+            if (GetFieldValue<string>(fieldValues, WikiField) != null)
             {
                 return WikiPage;
             }
 
-            if (GetFieldValue<string>(listItem, BSNField) != "")
+            if (GetFieldValue(fieldValues, FileTypeField, string.Empty).Equals(DelveBlogFileType, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return DelveBlogPage;
+            }
+
+            if (GetFieldValue<string>(fieldValues, BSNField) != "")
             {
                 return ASPXPage;
             }
@@ -329,6 +357,23 @@ namespace PnP.Scanning.Core.Scanners
             {
                 return WikiPage;
             }
+        }
+
+        // Pure extraction of the page "Modified By" display name (no CSOM) so it is unit-testable.
+        internal static string GetModifiedBy(IDictionary<string, object> fieldValues, bool skipUserInformation)
+        {
+            if (skipUserInformation)
+            {
+                return null;
+            }
+
+            if (fieldValues.TryGetValue(ModifiedByField, out object value) && value is IFieldUserValue user)
+            {
+                // For user fields loaded via list data stream the display name lands in LookupValue (and Title).
+                return !string.IsNullOrEmpty(user.LookupValue) ? user.LookupValue : user.Title;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary

Quick-win metadata parity for the classic page scan (backlog task **T3**, part of the
Modernization Scanner → M365 Assessment tool consolidation). Two small enrichments ported
from the legacy scanner's `ListItemExtensions`:

1. **Delve blog page typing** — classify pages with `File_x0020_Type == "pointpub"` as
   `DelveBlogPage` instead of falling through to a generic ASPX page.
2. **Page "Modified By" capture** — populate `ClassicPage.ModifiedBy` from the `Editor`
   user field, gated by the `SkipUserInformation` flag (T2).

Both helpers are extracted as pure functions over the raw list-item field dictionary, so
they are unit-tested directly without a live CSOM/SharePoint dependency. (The live page
path stays integration-only — T15.)

## Changes

- `Scanners/Classic/PageScanComponent.cs`
  - Add `DelveBlogPage` page-type constant + `pointpub` file-type check in `GetPageType`.
  - Refactor `GetPageType` into a pure overload over `IDictionary<string, object>`.
  - Add pure `GetModifiedBy(fieldValues, skipUserInformation)`; wire it into all three
    page-collection sites (blog, regular site pages, publishing pages).
  - Read `SkipUserInformation` from `ClassicOptions` at the top of `ExecuteAsync`.
- `PnP.Scanning.Core.Tests/Scanners/PageScanComponentTests.cs` (new)
  - 7 tests: Delve typing (+ case-insensitive + 3 non-Delve controls), ModifiedBy display
    name, Title fallback, `SkipUserInformation` → null, missing-field → null.

(The `ClassicPage.ModifiedBy` column and the `SkipUserInformation` option ship in T1/T2.)

## Parity with the legacy scanner

| Behavior | Legacy (`ListItemExtensions`) | This PR | Notes |
|---|---|---|---|
| Delve detection | `File_x0020_Type == "pointpub"` (CI), after wiki check | identical | exact parity |
| ModifiedBy value | `Email`, fallback `LookupValue` | `LookupValue` (display name), fallback `Title` | **intentional** — captures display name; matches list-data-stream behavior |
| Empty sentinel | `""` | `null` | harmless for CSV/DB |
| `SkipUserInformation` gating | none (always captured) | honored | additive improvement |

## Testing

`dotnet test --filter PageScanComponentTests` → **7 passed, 0 failed**.

## Backlog

Closes **T3** in `classic-page-scan-task-backlog`. Depends on T1 (column) + T2 (flag),
both merged.