### PR TITLE
Classic page scan (T5): CSOM web part extraction for WebPart + Wiki pages

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/WikiContentParserTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/WikiContentParserTests.cs
@@ -1,0 +1,167 @@
+﻿using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners.Pages
+{
+    /// <summary>
+    /// T5 — the pure (no CSOM) wiki-HTML parser. These tests feed it captured <c>WikiField</c> HTML and
+    /// assert the extracted web part placeholders (count + position + control id) and inline text blocks.
+    /// The <c>LimitedWebPartManager</c> resolution path that turns a placeholder into a typed web part is
+    /// CSOM-only and is covered by the integration test, not here.
+    /// </summary>
+    public class WikiContentParserTests
+    {
+        // A one-row, one-column wiki layout with: web part, then text, then a second web part.
+        private const string TwoWebPartsWithTextHtml = @"
+            <div class=""ExternalClassABC"">
+              <table id=""layoutsTable"" style=""width: 100%;"">
+                <tbody>
+                  <tr>
+                    <td style=""width: 100%;"">
+                      <div class=""ms-rte-layoutszone-outer"" style=""width: 100%;"">
+                        <div class=""ms-rte-layoutszone-inner"" style=""word-wrap: break-word; margin: 0px; border: 0px;"">
+                          <div class=""ms-rte-wpbox"">
+                            <div class=""ms-rtestate-read ms-rtestate-notify"" id=""div_11111111-1111-1111-1111-111111111111"" unselectable=""on"">&#160;</div>
+                          </div>
+                          <p>Hello wiki world</p>
+                          <div class=""ms-rte-wpbox"">
+                            <div class=""ms-rtestate-read ms-rtestate-notify"" id=""div_22222222-2222-2222-2222-222222222222"" unselectable=""on"">&#160;</div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>";
+
+        // A one-row, two-column layout, one web part in each column.
+        private const string TwoColumnHtml = @"
+            <div class=""ExternalClassABC"">
+              <table id=""layoutsTable"">
+                <tbody>
+                  <tr>
+                    <td style=""width: 49.95%;"">
+                      <div class=""ms-rte-layoutszone-outer"">
+                        <div class=""ms-rte-layoutszone-inner"">
+                          <div class=""ms-rte-wpbox"">
+                            <div class=""ms-rtestate-read"" id=""div_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"">&#160;</div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td style=""width: 49.95%;"">
+                      <div class=""ms-rte-layoutszone-outer"">
+                        <div class=""ms-rte-layoutszone-inner"">
+                          <div class=""ms-rte-wpbox"">
+                            <div class=""ms-rtestate-read"" id=""div_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"">&#160;</div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>";
+
+        // A layout table with text only — no web part boxes.
+        private const string TextOnlyHtml = @"
+            <div class=""ExternalClassABC"">
+              <table id=""layoutsTable"">
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class=""ms-rte-layoutszone-outer"">
+                        <div class=""ms-rte-layoutszone-inner"">
+                          <p>Just some article text, nothing embedded.</p>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>";
+
+        [Fact]
+        public void WikiHtml_Parse_ExtractsWebPartPlaceholders()
+        {
+            var result = WikiContentParser.Parse(TwoWebPartsWithTextHtml);
+
+            // Two embedded web parts; the text between them becomes a single WikiText block.
+            result.Placeholders.Should().HaveCount(2);
+
+            // Both web parts live in the single row/column of the layout.
+            result.Placeholders.Should().OnlyContain(p => p.Row == 1 && p.Column == 1);
+
+            // Order is interleaved with the text block: web part (1), text (2), web part (3).
+            result.Placeholders.Select(p => p.Order).Should().Equal(1, 3);
+
+            // The control id is taken from the page HTML and rewritten to the g_ form used by
+            // LimitedWebPartManager.GetByControlId.
+            var first = result.Placeholders[0];
+            first.Id.Should().Be("11111111-1111-1111-1111-111111111111");
+            first.ControlId.Should().Be("g_11111111_1111_1111_1111_111111111111");
+
+            result.Placeholders[1].Id.Should().Be("22222222-2222-2222-2222-222222222222");
+            result.Placeholders[1].ControlId.Should().Be("g_22222222_2222_2222_2222_222222222222");
+
+            // The inline text is captured as a WikiText part.
+            result.TextParts.Should().HaveCount(1);
+            result.TextParts[0].Type.Should().Be(WikiContentParser.WikiTextPartType);
+            result.TextParts[0].Order.Should().Be(2);
+            result.TextParts[0].Properties.Should().ContainKey("Text");
+            result.TextParts[0].Properties["Text"].Should().Contain("Hello wiki world");
+        }
+
+        [Fact]
+        public void WikiHtml_Parse_AssignsColumnNumbersPerLayoutColumn()
+        {
+            var result = WikiContentParser.Parse(TwoColumnHtml);
+
+            result.Placeholders.Should().HaveCount(2);
+            result.Placeholders.Select(p => p.Column).Should().Equal(1, 2);
+            result.Placeholders.Should().OnlyContain(p => p.Row == 1);
+            result.Placeholders[0].ControlId.Should().Be("g_aaaaaaaa_aaaa_aaaa_aaaa_aaaaaaaaaaaa");
+            result.Placeholders[1].ControlId.Should().Be("g_bbbbbbbb_bbbb_bbbb_bbbb_bbbbbbbbbbbb");
+        }
+
+        [Fact]
+        public void WikiHtml_NoWebParts_ReturnsEmpty()
+        {
+            var result = WikiContentParser.Parse(TextOnlyHtml);
+
+            // No embedded web parts...
+            result.Placeholders.Should().BeEmpty();
+
+            // ...but the article text is still recorded as a WikiText block.
+            result.TextParts.Should().ContainSingle();
+            result.TextParts[0].Properties["Text"].Should().Contain("Just some article text");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WikiHtml_EmptyInput_ReturnsNothing(string html)
+        {
+            var result = WikiContentParser.Parse(html);
+
+            result.Placeholders.Should().BeEmpty();
+            result.TextParts.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void WikiHtml_NonLayoutHtml_WrapsContentAsSingleTextPart()
+        {
+            // Content that isn't a standard wiki layout table still records a single text block so the
+            // page is not silently dropped.
+            var result = WikiContentParser.Parse("<div>free standing wiki content</div>");
+
+            result.Placeholders.Should().BeEmpty();
+            result.TextParts.Should().ContainSingle();
+            result.TextParts[0].Row.Should().Be(1);
+            result.TextParts[0].Column.Should().Be(1);
+            result.TextParts[0].Order.Should().Be(1);
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageWebPartExtractor.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageWebPartExtractor.cs
@@ -1,0 +1,468 @@
+﻿using System.Text.Json;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.WebParts;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
+using PnP.Scanning.Core.Storage;
+
+namespace PnP.Scanning.Core.Scanners
+{
+    /// <summary>
+    /// Turns a discovered classic page into its per-web-part inventory (<see cref="ClassicPageWebPart"/>
+    /// rows) using CSOM. Two extraction paths, mirroring the legacy Modernization Scanner:
+    /// <list type="bullet">
+    /// <item><description><b>Web part pages</b> — read the web parts straight off the page's
+    /// <c>LimitedWebPartManager</c>.</description></item>
+    /// <item><description><b>Wiki pages</b> — parse the <c>WikiField</c> HTML (pure, via
+    /// <see cref="WikiContentParser"/>) into text blocks + web part placeholders, then resolve the
+    /// placeholders against the page's <c>LimitedWebPartManager</c>.</description></item>
+    /// </list>
+    /// The <c>LimitedWebPartManager</c> round-trips cannot be unit-tested in isolation, so the live path
+    /// is exercised by the integration test; only the wiki-HTML parsing has its own unit tests. This
+    /// component intentionally does not persist anything (that is done by the storage layer) and does not
+    /// compute the mapping percentage (that is a separate task) — it just produces the rows.
+    /// </summary>
+    internal static class PageWebPartExtractor
+    {
+        // Web part type constants returned by the property-signature based type detection. Ported from
+        // the legacy WebParts constants (only the subset GetTypeFromProperties can return is needed).
+        private const string XsltListViewType = "Microsoft.SharePoint.WebPartPages.XsltListViewWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ListViewType = "Microsoft.SharePoint.WebPartPages.ListViewWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string MediaType = "Microsoft.SharePoint.Publishing.WebControls.MediaWebPart, Microsoft.SharePoint.Publishing, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string PictureLibrarySlideshowType = "Microsoft.SharePoint.WebPartPages.PictureLibrarySlideshowWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ChartType = "Microsoft.Office.Server.WebControls.ChartWebPart, Microsoft.Office.Server.Chart, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string MembersType = "Microsoft.SharePoint.WebPartPages.MembersWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string SilverlightType = "Microsoft.SharePoint.WebPartPages.SilverlightWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ClientType = "Microsoft.SharePoint.WebPartPages.ClientWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ContentEditorType = "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ImageType = "Microsoft.SharePoint.WebPartPages.ImageWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string TitleBarType = "Microsoft.SharePoint.WebPartPages.TitleBarWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ScriptEditorType = "Microsoft.SharePoint.WebPartPages.ScriptEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string SPUserCodeType = "Microsoft.SharePoint.WebPartPages.SPUserCodeWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+
+        private const string UnsupportedWebPartType = "Unsupported Web Part Type";
+
+        /// <summary>
+        /// Extracts the web part inventory for a web part page using its <c>LimitedWebPartManager</c>.
+        /// </summary>
+        /// <param name="csomContext">CSOM context for the web (already throttle-aware).</param>
+        /// <param name="page">The discovered classic page the rows belong to.</param>
+        /// <param name="exportWebPartProperties">When set, the web part properties are serialized to JSON.</param>
+        /// <param name="includeTitleBarWebPart">Include the TitleBar zone web part (off by default, as legacy).</param>
+        internal static async Task<List<ClassicPageWebPart>> ExtractFromWebPartPageAsync(ClientContext csomContext, ClassicPage page,
+                                                                                         bool exportWebPartProperties, bool includeTitleBarWebPart = false)
+        {
+            var webPartPage = csomContext.Web.GetFileByServerRelativeUrl(page.PageUrl);
+
+            var pageProperties = webPartPage.Properties;
+            csomContext.Load(pageProperties);
+
+            var limitedWPManager = webPartPage.GetLimitedWebPartManager(PersonalizationScope.Shared);
+            csomContext.Load(limitedWPManager);
+
+            var webParts = csomContext.LoadQuery(limitedWPManager.WebParts.IncludeWithDefaultProperties(
+                wp => wp.Id, wp => wp.ZoneId, wp => wp.WebPart.ExportMode, wp => wp.WebPart.Title,
+                wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden, wp => wp.WebPart.Properties));
+            await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+            var layout = GetWebPartPageLayout(pageProperties);
+
+            // Export the web part XML for the parts that allow it (gives the most reliable type).
+            var exportedXml = new Dictionary<Guid, ClientResult<string>>();
+            bool isDirty = false;
+            foreach (var foundWebPart in webParts)
+            {
+                if (!includeTitleBarWebPart && foundWebPart.ZoneId.Equals("TitleBar", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (foundWebPart.WebPart.ExportMode == WebPartExportMode.All)
+                {
+                    exportedXml[foundWebPart.Id] = limitedWPManager.ExportWebPart(foundWebPart.Id);
+                    isDirty = true;
+                }
+            }
+            if (isDirty)
+            {
+                await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+            }
+
+            var entities = new List<WebPartEntity>();
+            foreach (var foundWebPart in webParts)
+            {
+                if (!includeTitleBarWebPart && foundWebPart.ZoneId.Equals("TitleBar", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
+
+                exportedXml.TryGetValue(foundWebPart.Id, out var xml);
+                string webPartType = xml != null ? GetTypeFromXml(xml.Value) : GetTypeFromProperties(foundWebPart.WebPart.Properties.FieldValues);
+
+                entities.Add(new WebPartEntity
+                {
+                    Title = foundWebPart.WebPart.Title,
+                    Type = webPartType,
+                    Id = foundWebPart.Id,
+                    ServerControlId = foundWebPart.Id.ToString(),
+                    Row = GetRow(foundWebPart.ZoneId, layout),
+                    Column = GetColumn(foundWebPart.ZoneId, layout),
+                    Order = foundWebPart.WebPart.ZoneIndex,
+                    ZoneId = foundWebPart.ZoneId,
+                    ZoneIndex = (uint)foundWebPart.WebPart.ZoneIndex,
+                    IsClosed = foundWebPart.WebPart.IsClosed,
+                    Hidden = foundWebPart.WebPart.Hidden,
+                    Properties = ToStringProperties(foundWebPart.WebPart.Properties.FieldValues),
+                });
+            }
+
+            return ToRows(page, entities, exportWebPartProperties);
+        }
+
+        /// <summary>
+        /// Extracts the web part inventory for a wiki page: parses the supplied <c>WikiField</c> HTML and
+        /// resolves the embedded web part placeholders against the page's <c>LimitedWebPartManager</c>.
+        /// </summary>
+        /// <param name="csomContext">CSOM context for the web (already throttle-aware).</param>
+        /// <param name="page">The discovered classic page the rows belong to.</param>
+        /// <param name="wikiFieldHtml">The page's <c>WikiField</c> HTML.</param>
+        /// <param name="exportWebPartProperties">When set, the web part properties are serialized to JSON.</param>
+        internal static async Task<List<ClassicPageWebPart>> ExtractFromWikiPageAsync(ClientContext csomContext, ClassicPage page,
+                                                                                      string wikiFieldHtml, bool exportWebPartProperties)
+        {
+            // Pure HTML parsing: text blocks + placeholders for the embedded web parts.
+            var parsed = WikiContentParser.Parse(wikiFieldHtml);
+
+            var entities = new List<WebPartEntity>(parsed.TextParts);
+
+            if (parsed.Placeholders.Count > 0)
+            {
+                var wikiPage = csomContext.Web.GetFileByServerRelativeUrl(page.PageUrl);
+                var limitedWPManager = wikiPage.GetLimitedWebPartManager(PersonalizationScope.Shared);
+                csomContext.Load(limitedWPManager);
+
+                var definitions = new Dictionary<WikiWebPartPlaceholder, WebPartDefinition>();
+                foreach (var placeholder in parsed.Placeholders)
+                {
+                    // Sometimes the wiki html references web parts that are no longer on the page; the
+                    // ExceptionHandlingScope lets the server tolerate those in a single round-trip.
+                    var scope = new ExceptionHandlingScope(csomContext);
+                    using (scope.StartScope())
+                    {
+                        using (scope.StartTry())
+                        {
+                            var definition = limitedWPManager.WebParts.GetByControlId(placeholder.ControlId);
+                            csomContext.Load(definition, wp => wp.Id, wp => wp.WebPart.ExportMode, wp => wp.WebPart.Title,
+                                             wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden, wp => wp.WebPart.Properties);
+                            definitions[placeholder] = definition;
+                        }
+                        using (scope.StartCatch())
+                        {
+                        }
+                    }
+                }
+                await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+                // Export the web part XML for the parts that allow it.
+                var exportedXml = new Dictionary<WikiWebPartPlaceholder, ClientResult<string>>();
+                bool isDirty = false;
+                foreach (var (placeholder, definition) in definitions)
+                {
+                    if (definition.ServerObjectIsNull == false && definition.WebPart.ExportMode == WebPartExportMode.All)
+                    {
+                        exportedXml[placeholder] = limitedWPManager.ExportWebPart(definition.Id);
+                        isDirty = true;
+                    }
+                }
+                if (isDirty)
+                {
+                    await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+                }
+
+                foreach (var placeholder in parsed.Placeholders)
+                {
+                    if (!definitions.TryGetValue(placeholder, out var definition) || definition.ServerObjectIsNull != false)
+                    {
+                        continue;
+                    }
+
+                    exportedXml.TryGetValue(placeholder, out var xml);
+                    string webPartType = xml != null ? GetTypeFromXml(xml.Value) : GetTypeFromProperties(definition.WebPart.Properties.FieldValues);
+
+                    entities.Add(new WebPartEntity
+                    {
+                        Title = definition.WebPart.Title,
+                        Type = webPartType,
+                        Id = definition.Id,
+                        ServerControlId = placeholder.Id,
+                        Row = placeholder.Row,
+                        Column = placeholder.Column,
+                        Order = placeholder.Order,
+                        ZoneId = "",
+                        ZoneIndex = (uint)definition.WebPart.ZoneIndex,
+                        IsClosed = definition.WebPart.IsClosed,
+                        Hidden = definition.WebPart.Hidden,
+                        Properties = ToStringProperties(definition.WebPart.Properties.FieldValues),
+                    });
+                }
+            }
+
+            // Present the inventory in document order (row, then column, then order).
+            var ordered = entities.OrderBy(w => w.Row).ThenBy(w => w.Column).ThenBy(w => w.Order).ToList();
+            return ToRows(page, ordered, exportWebPartProperties);
+        }
+
+        private static List<ClassicPageWebPart> ToRows(ClassicPage page, List<WebPartEntity> entities, bool exportWebPartProperties)
+        {
+            var rows = new List<ClassicPageWebPart>();
+            int index = 0;
+            foreach (var entity in entities)
+            {
+                rows.Add(new ClassicPageWebPart
+                {
+                    ScanId = page.ScanId,
+                    SiteUrl = page.SiteUrl,
+                    WebUrl = page.WebUrl,
+                    PageUrl = page.PageUrl,
+                    WebPartIndex = index++,
+                    WebPartType = entity.Type,
+                    WebPartTypeShort = entity.TypeShort(),
+                    WebPartTitle = entity.Title,
+                    WebPartProperties = exportWebPartProperties ? SerializeProperties(entity.Properties) : null,
+                    ZoneId = entity.ZoneId,
+                    Row = entity.Row,
+                    Column = entity.Column,
+                    Order = entity.Order,
+                    Hidden = entity.Hidden,
+                    IsClosed = entity.IsClosed,
+                    // IsMappable is computed later (mapping percentage task).
+                });
+            }
+
+            return rows;
+        }
+
+        private static string SerializeProperties(Dictionary<string, string> properties)
+        {
+            if (properties == null || properties.Count == 0)
+            {
+                return null;
+            }
+
+            return JsonSerializer.Serialize(properties);
+        }
+
+        private static Dictionary<string, string> ToStringProperties(IDictionary<string, object> fieldValues)
+        {
+            var properties = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            if (fieldValues != null)
+            {
+                foreach (var prop in fieldValues)
+                {
+                    if (!properties.ContainsKey(prop.Key))
+                    {
+                        properties.Add(prop.Key, prop.Value?.ToString() ?? "");
+                    }
+                }
+            }
+
+            return properties;
+        }
+
+        // Determines the web part type from its exported XML. Ported from BasePage.GetType.
+        private static string GetTypeFromXml(string webPartXml)
+        {
+            string type = "Unknown";
+
+            if (!string.IsNullOrEmpty(webPartXml))
+            {
+                var xml = XElement.Parse(webPartXml);
+                var xmlns = xml.XPathSelectElement("*").GetDefaultNamespace();
+                if (xmlns.NamespaceName.Equals("http://schemas.microsoft.com/WebPart/v3", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    type = xml.Descendants(xmlns + "type").FirstOrDefault()?.Attribute("name")?.Value ?? type;
+                }
+                else if (xmlns.NamespaceName.Equals("http://schemas.microsoft.com/WebPart/v2", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    type = $"{xml.Descendants(xmlns + "TypeName").FirstOrDefault()?.Value}, {xml.Descendants(xmlns + "Assembly").FirstOrDefault()?.Value}";
+                }
+            }
+
+            return type;
+        }
+
+        // Determines the web part type by detecting it from the available properties. Ported from
+        // BasePage.GetTypeFromProperties (online code path; the on-premises legacy branch is not ported).
+        private static string GetTypeFromProperties(IDictionary<string, object> properties)
+        {
+            if (HasAll(properties, "ListUrl", "ListId", "Xsl", "JSLink", "ShowTimelineIfAvailable")) return XsltListViewType;
+            if (HasAll(properties, "ListViewXml", "ListName", "ListId", "ViewContentTypeId", "PageType")) return ListViewType;
+            if (HasAll(properties, "AutoPlay", "MediaSource", "Loop", "IsPreviewImageSourceOverridenForVideoSet", "PreviewImageSource")) return MediaType;
+            if (HasAll(properties, "LibraryGuid", "Layout", "Speed", "ShowToolbar", "ViewGuid")) return PictureLibrarySlideshowType;
+            if (HasAll(properties, "ConnectionPointEnabled", "ChartXml", "DataBindingsString", "DesignerChartTheme")) return ChartType;
+            if (HasAll(properties, "NumberLimit", "DisplayType", "MembershipGroupId", "Toolbar")) return MembersType;
+            if (HasAll(properties, "MinRuntimeVersion", "WindowlessMode", "CustomInitParameters", "Url", "ApplicationXml")) return SilverlightType;
+            if (HasAll(properties, "FeatureId", "ProductWebId", "ProductId")) return ClientType;
+            if (HasAll(properties, "Content")) return ScriptEditorType;
+            if (HasAll(properties, "CatalogIconImageUrl", "AllowEdit", "TitleIconImageUrl", "ExportMode")) return SPUserCodeType;
+
+            return UnsupportedWebPartType;
+        }
+
+        private static bool HasAll(IDictionary<string, object> properties, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (!properties.ContainsKey(key))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Determines the web part page layout from the page file properties. Ported from
+        // WebPartPage.GetLayout.
+        private static PageLayout GetWebPartPageLayout(PropertyValues pageProperties)
+        {
+            if (pageProperties.FieldValues.ContainsKey("vti_setuppath"))
+            {
+                var setupPath = pageProperties["vti_setuppath"]?.ToString();
+                if (!string.IsNullOrEmpty(setupPath))
+                {
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd1.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_FullPageVertical;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd2.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooterThreeColumns;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd3.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderLeftColumnBody;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd4.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderRightColumnBody;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd5.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooter2Columns4Rows;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd6.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooter4ColumnsTopRow;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd7.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns;
+                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd8.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns;
+                    if (setupPath.Equals(@"SiteTemplates\STS\default.aspx", StringComparison.InvariantCultureIgnoreCase)) return PageLayout.WebPart_2010_TwoColumnsLeft;
+                }
+            }
+
+            return PageLayout.WebPart_Custom;
+        }
+
+        // Translates the given zone value and page layout to a column number. Ported from WebPartPage.GetColumn.
+        private static int GetColumn(string zoneId, PageLayout layout)
+        {
+            switch (layout)
+            {
+                case PageLayout.WebPart_HeaderFooterThreeColumns:
+                    if (IsZone(zoneId, "Header", "LeftColumn", "Footer")) return 1;
+                    if (IsZone(zoneId, "MiddleColumn")) return 2;
+                    if (IsZone(zoneId, "RightColumn")) return 3;
+                    break;
+                case PageLayout.WebPart_FullPageVertical:
+                    return 1;
+                case PageLayout.WebPart_HeaderLeftColumnBody:
+                    if (IsZone(zoneId, "Header", "LeftColumn")) return 1;
+                    if (IsZone(zoneId, "Body")) return 2;
+                    break;
+                case PageLayout.WebPart_HeaderRightColumnBody:
+                    if (IsZone(zoneId, "Header", "Body")) return 1;
+                    if (IsZone(zoneId, "RightColumn")) return 2;
+                    break;
+                case PageLayout.WebPart_HeaderFooter2Columns4Rows:
+                    if (IsZone(zoneId, "Header", "Footer", "LeftColumn")) return 1;
+                    if (IsZone(zoneId, "Row1", "Row2", "Row3", "Row4")) return 2;
+                    if (IsZone(zoneId, "RightColumn")) return 3;
+                    break;
+                case PageLayout.WebPart_HeaderFooter4ColumnsTopRow:
+                    if (IsZone(zoneId, "Header", "Footer", "LeftColumn")) return 1;
+                    if (IsZone(zoneId, "TopRow", "CenterRightColumn", "CenterLeftColumn")) return 2;
+                    if (IsZone(zoneId, "RightColumn")) return 3;
+                    break;
+                case PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns:
+                    if (IsZone(zoneId, "Header", "LeftColumn", "CenterLeftColumn", "Footer", "TopRow")) return 1;
+                    if (IsZone(zoneId, "CenterColumn")) return 2;
+                    if (IsZone(zoneId, "CenterRightColumn")) return 3;
+                    break;
+                case PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns:
+                    if (IsZone(zoneId, "Header", "RightColumn", "CenterLeftColumn", "Footer", "TopRow")) return 1;
+                    if (IsZone(zoneId, "CenterColumn")) return 2;
+                    if (IsZone(zoneId, "CenterRightColumn")) return 3;
+                    break;
+                case PageLayout.WebPart_2010_TwoColumnsLeft:
+                    if (IsZone(zoneId, "Left")) return 1;
+                    if (IsZone(zoneId, "Right")) return 2;
+                    break;
+                case PageLayout.WebPart_Custom:
+                    return 1;
+                default:
+                    return 1;
+            }
+
+            return 1;
+        }
+
+        // Translates the given zone value and page layout to a row number. Ported from WebPartPage.GetRow.
+        private static int GetRow(string zoneId, PageLayout layout)
+        {
+            switch (layout)
+            {
+                case PageLayout.WebPart_HeaderFooterThreeColumns:
+                    if (IsZone(zoneId, "Header")) return 1;
+                    if (IsZone(zoneId, "LeftColumn", "MiddleColumn", "RightColumn")) return 2;
+                    if (IsZone(zoneId, "Footer")) return 3;
+                    break;
+                case PageLayout.WebPart_FullPageVertical:
+                case PageLayout.WebPart_2010_TwoColumnsLeft:
+                    return 1;
+                case PageLayout.WebPart_HeaderLeftColumnBody:
+                    if (IsZone(zoneId, "Header")) return 1;
+                    if (IsZone(zoneId, "LeftColumn", "Body")) return 2;
+                    break;
+                case PageLayout.WebPart_HeaderRightColumnBody:
+                    if (IsZone(zoneId, "Header")) return 1;
+                    if (IsZone(zoneId, "RightColumn", "Body")) return 2;
+                    break;
+                case PageLayout.WebPart_HeaderFooter2Columns4Rows:
+                    if (IsZone(zoneId, "Header")) return 1;
+                    if (IsZone(zoneId, "LeftColumn", "Row1", "RightColumn", "Row2", "Row3", "Row4")) return 2;
+                    if (IsZone(zoneId, "Footer")) return 3;
+                    break;
+                case PageLayout.WebPart_HeaderFooter4ColumnsTopRow:
+                    if (IsZone(zoneId, "Header")) return 1;
+                    if (IsZone(zoneId, "LeftColumn", "TopRow", "RightColumn", "CenterLeftColumn", "CenterRightColumn")) return 2;
+                    if (IsZone(zoneId, "Footer")) return 3;
+                    break;
+                case PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns:
+                    if (IsZone(zoneId, "Header", "LeftColumn")) return 1;
+                    if (IsZone(zoneId, "TopRow")) return 2;
+                    if (IsZone(zoneId, "CenterLeftColumn", "CenterColumn", "CenterRightColumn")) return 3;
+                    if (IsZone(zoneId, "Footer")) return 4;
+                    break;
+                case PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns:
+                    if (IsZone(zoneId, "Header", "RightColumn")) return 1;
+                    if (IsZone(zoneId, "TopRow")) return 2;
+                    if (IsZone(zoneId, "CenterLeftColumn", "CenterColumn", "CenterRightColumn")) return 3;
+                    if (IsZone(zoneId, "Footer")) return 4;
+                    break;
+                case PageLayout.WebPart_Custom:
+                    return 1;
+                default:
+                    return 1;
+            }
+
+            return 1;
+        }
+
+        private static bool IsZone(string zoneId, params string[] candidates)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (zoneId.Equals(candidate, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/WikiContentParser.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/WikiContentParser.cs
@@ -1,0 +1,392 @@
+﻿using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using System.Text;
+using System.Text.RegularExpressions;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
+
+namespace PnP.Scanning.Core.Scanners
+{
+    /// <summary>
+    /// Pure (no CSOM) parser of a classic wiki page's <c>WikiField</c> HTML. It walks the wiki layout
+    /// table and extracts:
+    /// <list type="bullet">
+    /// <item><description>the inline <c>WikiText</c> blocks as fully resolved <see cref="WebPartEntity"/> records, and</description></item>
+    /// <item><description>placeholders (<see cref="WikiWebPartPlaceholder"/>) for the real web parts embedded in the wiki —
+    /// these carry the control id + position only; the actual web part type/title/properties must be
+    /// resolved against the live page via CSOM (<c>LimitedWebPartManager</c>), which is deferred to the
+    /// page web part extractor / integration test.</description></item>
+    /// </list>
+    /// Ported from the legacy SharePoint Modernization Scanner
+    /// (<c>SharePointPnP.Modernization.Framework\Pages\BasePage.AnalyzeWikiContentBlock</c> +
+    /// <c>WikiPage.Analyze</c>), with the CSOM and page-layout detection (a separate task) stripped out so
+    /// the HTML parsing is unit-testable on its own.
+    /// </summary>
+    internal static class WikiContentParser
+    {
+        // Marker inserted where a web part div used to be, so surrounding text can be split around it.
+        private const string WebPartMarkerString = "[[WebPartMarker]]";
+
+        // The fake "type" used for the wiki text blocks; matches the legacy WebParts.WikiText constant so
+        // the mapping lookup (which knows this type as a ClientSideText mapping) treats it as mappable.
+        internal const string WikiTextPartType = "SharePointPnP.Modernization.WikiTextPart";
+
+        // Pulls the server side control id out of a web part box (e.g. id="div_8c4f...-...." ).
+        private static readonly Regex RegexClientIds = new(@"id=\""div_(?<ControlId>(\w|\-)+)", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses the supplied wiki field HTML into its inline text blocks and embedded web part
+        /// placeholders. Never returns null; an empty/whitespace input yields an empty result.
+        /// </summary>
+        internal static WikiContentParseResult Parse(string wikiFieldHtml)
+        {
+            var result = new WikiContentParseResult();
+
+            if (string.IsNullOrEmpty(wikiFieldHtml))
+            {
+                // Empty wiki page: nothing to extract (the legacy scanner would treat this as a single
+                // empty one-column layout, but there are no web parts and no text to record).
+                return result;
+            }
+
+            var parser = new HtmlParser();
+            var htmlDoc = parser.ParseDocument(wikiFieldHtml);
+
+            var rows = htmlDoc.All.Where(p => p.LocalName == "tr");
+            int rowCount = 0;
+
+            foreach (var row in rows)
+            {
+                rowCount++;
+                var columns = row.Children.Where(p => p.LocalName == "td" && p.Parent == row);
+
+                int colCount = 0;
+                foreach (var column in columns)
+                {
+                    colCount++;
+                    var contentHost = column.Children.FirstOrDefault(p => p.LocalName == "div" &&
+                        p.ClassName != null && p.ClassName.Equals("ms-rte-layoutszone-outer", StringComparison.InvariantCultureIgnoreCase));
+
+                    // Skip elements nested inside an already processed content host to avoid duplication.
+                    if (contentHost != null && contentHost.FirstElementChild != null && !IsNestedLayoutsZoneOuter(contentHost))
+                    {
+                        var content = contentHost.FirstElementChild;
+                        AnalyzeWikiContentBlock(parser, result, htmlDoc, rowCount, colCount, 0, content);
+                    }
+                }
+            }
+
+            // Somehow the wiki was not standard formatted (no layout table we could walk): wrap the whole
+            // content in a single text block so the page still records something. Matches the legacy
+            // fallback, evaluated here only against the text/placeholders we could extract (the CSOM web
+            // part resolution happens later, so we key off "nothing found at all").
+            if (result.Placeholders.Count == 0 && result.TextParts.Count == 0)
+            {
+                result.TextParts.Add(CreateWikiTextPart(wikiFieldHtml, 1, 1, 1));
+            }
+
+            return result;
+        }
+
+        // Ported from BasePage.AnalyzeWikiContentBlock — walks one content host's child nodes, emitting
+        // interleaved WikiText parts and web part placeholders in document order.
+        private static void AnalyzeWikiContentBlock(HtmlParser parser, WikiContentParseResult result, IHtmlDocument htmlDoc,
+                                                    int rowCount, int colCount, int startOrder, IElement content)
+        {
+            // Drop elements which we anyhow can't transform and/or which are stripped out from RTE.
+            CleanHtml(content, htmlDoc);
+
+            StringBuilder textContent = new();
+            int order = startOrder;
+            foreach (var node in content.ChildNodes)
+            {
+                // Do we find a web part inside...
+                if (node is IHtmlElement htmlElement && ContainsWebPart(parser, htmlElement))
+                {
+                    var extraText = StripWebPart(parser, htmlElement);
+                    string extraTextAfterWebPart = null;
+                    string extraTextBeforeWebPart = null;
+                    if (!string.IsNullOrEmpty(extraText))
+                    {
+                        // Should be, but checking anyhow
+                        int webPartMarker = extraText.IndexOf(WebPartMarkerString);
+                        if (webPartMarker > -1)
+                        {
+                            extraTextBeforeWebPart = extraText.Substring(0, webPartMarker);
+                            extraTextAfterWebPart = extraText.Substring(webPartMarker + WebPartMarkerString.Length);
+
+                            // there could have been multiple web parts in a row (we don't support text
+                            // inbetween them for now)...strip the remaining markers
+                            extraTextBeforeWebPart = extraTextBeforeWebPart.Replace(WebPartMarkerString, "");
+                            extraTextAfterWebPart = extraTextAfterWebPart.Replace(WebPartMarkerString, "");
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(extraTextBeforeWebPart))
+                    {
+                        textContent.AppendLine(extraTextBeforeWebPart);
+                    }
+
+                    // first insert text part (if it was available)
+                    if (!string.IsNullOrEmpty(textContent.ToString()))
+                    {
+                        order++;
+                        result.TextParts.Add(CreateWikiTextPart(textContent.ToString(), rowCount, colCount, order));
+                        textContent.Clear();
+                    }
+
+                    // then process the web part
+                    order++;
+                    if (RegexClientIds.IsMatch(htmlElement.OuterHtml))
+                    {
+                        foreach (Match webPartMatch in RegexClientIds.Matches(htmlElement.OuterHtml))
+                        {
+                            // Store the web part we need, will be retrieved afterwards via CSOM.
+                            string serverSideControlId = webPartMatch.Groups["ControlId"].Value;
+                            var serverSideControlIdToSearchFor = $"g_{serverSideControlId.Replace("-", "_")}";
+                            result.Placeholders.Add(new WikiWebPartPlaceholder
+                            {
+                                ControlId = serverSideControlIdToSearchFor,
+                                Id = serverSideControlId,
+                                Row = rowCount,
+                                Column = colCount,
+                                Order = order,
+                            });
+                        }
+                    }
+
+                    // Process the extra text that was positioned after the web part (if any)
+                    if (!string.IsNullOrEmpty(extraTextAfterWebPart))
+                    {
+                        textContent.AppendLine(extraTextAfterWebPart);
+                    }
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(node.TextContent.Trim()) && node.TextContent.Trim() == "\n")
+                    {
+                        // ignore, this one is typically added after a web part
+                    }
+                    else
+                    {
+                        if (node.HasChildNodes)
+                        {
+                            textContent.AppendLine((node as IHtmlElement)?.OuterHtml);
+                        }
+                        else
+                        {
+                            if (!string.IsNullOrEmpty(node.TextContent.Trim()))
+                            {
+                                textContent.AppendLine(node.TextContent);
+                            }
+                            else
+                            {
+                                if (node.NodeName.Equals("br", StringComparison.InvariantCultureIgnoreCase))
+                                {
+                                    textContent.AppendLine("<BR>");
+                                }
+                                // given that wiki html can contain embedded images and videos while not
+                                // having child nodes we need include these.
+                                else if (node.NodeName.Equals("img", StringComparison.InvariantCultureIgnoreCase) ||
+                                         node.NodeName.Equals("iframe", StringComparison.InvariantCultureIgnoreCase))
+                                {
+                                    textContent.AppendLine((node as IHtmlElement)?.OuterHtml);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // there was only one text part
+            if (!string.IsNullOrEmpty(textContent.ToString()))
+            {
+                // insert text part to the web part collection
+                order++;
+                result.TextParts.Add(CreateWikiTextPart(textContent.ToString(), rowCount, colCount, order));
+            }
+        }
+
+        /// <summary>
+        /// Check if this element is nested in another already processed element...this needs to be
+        /// skipped to avoid content duplication and possible processing errors.
+        /// </summary>
+        private static bool IsNestedLayoutsZoneOuter(IElement contentHost)
+        {
+            var elementToInspect = contentHost?.ParentElement;
+
+            while (elementToInspect != null)
+            {
+                if (elementToInspect.LocalName == "div" && elementToInspect.ClassName != null &&
+                    elementToInspect.ClassName.Equals("ms-rte-layoutszone-outer", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+
+                elementToInspect = elementToInspect.ParentElement;
+            }
+
+            return false;
+        }
+
+        // Stores text content as a fake web part. Ported from BasePage.CreateWikiTextPart.
+        private static WebPartEntity CreateWikiTextPart(string wikiTextPartContent, int row, int col, int order)
+        {
+            return new WebPartEntity
+            {
+                Title = "WikiText",
+                Type = WikiTextPartType,
+                Id = Guid.Empty,
+                Row = row,
+                Column = col,
+                Order = order,
+                Properties = new Dictionary<string, string>
+                {
+                    { "Text", wikiTextPartContent.Trim().Replace("\r\n", string.Empty) }
+                },
+            };
+        }
+
+        private static void CleanHtml(IElement element, IHtmlDocument document)
+        {
+            foreach (var node in element.QuerySelectorAll("*").ToList())
+            {
+                if (node.ParentElement != null && IsUntransformableBlockElement(node))
+                {
+                    // create new div node and add all current children to it
+                    var div = document.CreateElement("div");
+                    foreach (var child in node.ChildNodes.ToList())
+                    {
+                        div.AppendChild(child);
+                    }
+                    // replace the unsupported node with the new div
+                    node.ParentElement.ReplaceChild(div, node);
+                }
+            }
+        }
+
+        private static bool IsUntransformableBlockElement(IElement element)
+        {
+            var tag = element.TagName.ToLower();
+            switch (tag)
+            {
+                case "article":
+                case "address":
+                case "aside":
+                case "canvas":
+                case "dd":
+                case "dl":
+                case "dt":
+                case "fieldset":
+                case "figcaption":
+                case "figure":
+                case "footer":
+                case "form":
+                case "header":
+                case "main":
+                case "nav":
+                case "noscript":
+                case "output":
+                case "pre":
+                case "section":
+                case "tfoot":
+                case "video":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Does the tree of nodes somewhere contain a web part?
+        /// </summary>
+        private static bool ContainsWebPart(HtmlParser parser, IHtmlElement element)
+        {
+            var doc = parser.ParseDocument(element.OuterHtml);
+            var nodes = doc.All.Where(p => p.LocalName == "div");
+            foreach (var node in nodes)
+            {
+                if (node is IHtmlElement htmlNode && htmlNode.ClassList.Contains("ms-rte-wpbox"))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Strips the div holding the web part from the html, replacing it with a marker so the
+        /// surrounding text can be recovered.
+        /// </summary>
+        private static string StripWebPart(HtmlParser parser, IHtmlElement element)
+        {
+            IElement copy = element.Clone(true) as IElement;
+            var doc = parser.ParseDocument(copy.OuterHtml);
+            var nodes = doc.All.Where(p => p.LocalName == "div");
+            if (nodes.Any())
+            {
+                foreach (var node in nodes.ToList())
+                {
+                    if (node is IHtmlElement htmlNode && htmlNode.ClassList.Contains("ms-rte-wpbox"))
+                    {
+                        var newElement = doc.CreateTextNode(WebPartMarkerString);
+                        node.Parent.ReplaceChild(newElement, node);
+                    }
+                }
+
+                if (doc.DocumentElement.Children[1].FirstElementChild != null &&
+                    doc.DocumentElement.Children[1].FirstElementChild is IHtmlDivElement)
+                {
+                    return doc.DocumentElement.Children[1].FirstElementChild.InnerHtml;
+                }
+                else
+                {
+                    return doc.DocumentElement.Children[1].InnerHtml;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Result of parsing a wiki page's HTML: the inline text blocks and the placeholders for the
+    /// embedded web parts (which still need a CSOM round-trip to resolve their type/properties).
+    /// </summary>
+    internal sealed class WikiContentParseResult
+    {
+        /// <summary>
+        /// Placeholders for the real web parts embedded in the wiki content, in document order.
+        /// </summary>
+        public List<WikiWebPartPlaceholder> Placeholders { get; } = new();
+
+        /// <summary>
+        /// The inline wiki text blocks, already fully resolved as <see cref="WebPartEntity"/> records.
+        /// </summary>
+        public List<WebPartEntity> TextParts { get; } = new();
+    }
+
+    /// <summary>
+    /// A reference to a web part embedded in wiki content. Carries the position and the server side
+    /// control id needed to look the web part up via <c>LimitedWebPartManager.WebParts.GetByControlId</c>.
+    /// </summary>
+    internal sealed class WikiWebPartPlaceholder
+    {
+        /// <summary>Raw control id as found in the page HTML (e.g. the web part definition guid).</summary>
+        public string Id { get; set; }
+
+        /// <summary>Control id in the <c>g_xxxx</c> form used by <c>GetByControlId</c>.</summary>
+        public string ControlId { get; set; }
+
+        /// <summary>Wiki layout row (1-based).</summary>
+        public int Row { get; set; }
+
+        /// <summary>Wiki layout column (1-based).</summary>
+        public int Column { get; set; }
+
+        /// <summary>Order of the web part within its row/column.</summary>
+        public int Order { get; set; }
+    }
+}


### PR DESCRIPTION
## What

Adds per-page **web part extraction** to the classic page scan (the core gap carried over
from the legacy Modernization Scanner), turning a discovered WebPart/Wiki page into
`ClassicPageWebPart` rows.

- **`Scanners/Classic/Pages/WikiContentParser.cs`** — a **pure, CSOM-free** parser of a wiki
  page's `WikiField` HTML. Walks the wiki layout table and returns inline `WikiText` blocks
  plus placeholders (control id + row/col/order) for the embedded web parts. Ported from the
  legacy `BasePage.AnalyzeWikiContentBlock` + `WikiPage.Analyze`.
- **`Scanners/Classic/Pages/PageWebPartExtractor.cs`** — the CSOM extraction that produces
  `List<ClassicPageWebPart>`:
  - `ExtractFromWebPartPageAsync` — reads `LimitedWebPartManager.WebParts`, derives row/col from
    the ported web-part-page layout logic.
  - `ExtractFromWikiPageAsync` — runs the parser, then resolves placeholders via
    `GetByControlId` inside an `ExceptionHandlingScope`.
  - Type detection ported from legacy `GetType`(XML) + `GetTypeFromProperties` (online branch).

## Why

`PnP.Scanning`'s Classic mode discovers and classifies classic pages but produces no web part
inventory — the prerequisite for page-transformation-readiness analysis. This is an enrichment
on the existing `PageScanComponent`, not a rewrite.

## Scope / design notes

- **Pure parser is the unit-tested deliverable.** The `LimitedWebPartManager` round-trips can't be
  unit-tested in isolation, so the live CSOM path is deferred to the integration test (T15); only the
  wiki-HTML parsing has UTs here.
- **Not wired into `PageScanComponent.ExecuteAsync`** — the per-web call + bulk insert is owned by
  T8, so wiring it now would ship wasted per-page CSOM work between PRs.
- `IsMappable` is left unset (mapping % is T6); page-level `Layout` is T7.
- Uses `csomContext.ExecuteQueryAsync()` — this repo has no `ExecuteQueryRetry`; retry/ratelimit ride
  the existing `HttpClientWebRequestExecutorFactory` (same pattern as `WorkflowScanComponent`).
- SPO-only: the legacy on-prem / SP2010 / WebPartPages.asmx fallbacks are intentionally not ported.
- New files saved as UTF-8 BOM + CRLF to match the repo.

## Tests

`Tests/Scanners/Pages/WikiContentParserTests.cs` — 6 cases: interleaved web part + text, two-column
layout, text-only, null/empty input, and non-layout content wrap. Full suite green (32 passed,
0 failed); core builds with 0 warnings.

## Follow-ups (parity gaps found while reviewing T5, tracked in the backlog)

- **T5a** — wiki embedded media (`WikiImagePart`/`WikiVideoPart`/`WikiEmbedPart`) is currently folded
  into `WikiText`; the newer mapping file knows these as mappable, so this should land before T6.
- **T5b** — publishing pages don't yet get a web part inventory (`ExtractFromPublishingPageAsync`).