### PR TITLE
Classic page scan (T5b): publishing page web part extraction

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageWebPartExtractorTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageWebPartExtractorTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners.Pages
+{
+    /// <summary>
+    /// T5b — the CSOM-free sub-logic the publishing-page (and web-part-page) extraction relies on:
+    /// determining a web part's type from its exported XML or, when it cannot be exported, from its
+    /// property signature. The <c>LimitedWebPartManager</c> round-trip in
+    /// <c>PageWebPartExtractor.ExtractFromPublishingPageAsync</c> is CSOM-only and is exercised by the
+    /// integration test (T15), not here.
+    /// </summary>
+    public class PageWebPartExtractorTests
+    {
+        [Theory]
+        // ScriptEditor is detected purely by the presence of a "Content" property.
+        [InlineData("ScriptEditorWebPart", "Content")]
+        // The full distinguishing signature for an XSLT list view.
+        [InlineData("XsltListViewWebPart", "ListUrl", "ListId", "Xsl", "JSLink", "ShowTimelineIfAvailable")]
+        // A members web part.
+        [InlineData("MembersWebPart", "NumberLimit", "DisplayType", "MembershipGroupId", "Toolbar")]
+        // A media web part.
+        [InlineData("MediaWebPart", "AutoPlay", "MediaSource", "Loop", "IsPreviewImageSourceOverridenForVideoSet", "PreviewImageSource")]
+        public void GetTypeFromProperties_KnownSignature_ResolvesType(string expectedTypeFragment, params string[] propertyNames)
+        {
+            var properties = new Dictionary<string, object>();
+            foreach (var name in propertyNames)
+            {
+                properties.Add(name, "value");
+            }
+
+            var type = PageWebPartExtractor.GetTypeFromProperties(properties);
+
+            type.Should().Contain(expectedTypeFragment);
+        }
+
+        [Fact]
+        public void GetTypeFromProperties_UnknownSignature_ReturnsUnsupported()
+        {
+            var properties = new Dictionary<string, object>
+            {
+                { "SomeRandomProperty", "value" },
+            };
+
+            var type = PageWebPartExtractor.GetTypeFromProperties(properties);
+
+            type.Should().Be("Unsupported Web Part Type");
+        }
+
+        [Fact]
+        public void GetTypeFromXml_V3WebPart_ReturnsTypeName()
+        {
+            // The exported XML for a modern (v3) web part carries the fully-qualified type in
+            // metaData/type/@name.
+            const string v3Xml = @"<webParts xmlns=""http://schemas.microsoft.com/WebPart/v3"">
+              <webPart>
+                <metaData>
+                  <type name=""Microsoft.SharePoint.WebPartPages.ContentEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c"" />
+                </metaData>
+              </webPart>
+            </webParts>";
+
+            var type = PageWebPartExtractor.GetTypeFromXml(v3Xml);
+
+            type.Should().Be("Microsoft.SharePoint.WebPartPages.ContentEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c");
+        }
+
+        [Fact]
+        public void GetTypeFromXml_V2WebPart_ReturnsTypeNameAndAssembly()
+        {
+            // A legacy (v2) export splits the type into a TypeName + Assembly pair which is recombined
+            // into the "TypeName, Assembly" form.
+            const string v2Xml = @"<WebPart xmlns=""http://schemas.microsoft.com/WebPart/v2"">
+              <Assembly>Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c</Assembly>
+              <TypeName>Microsoft.SharePoint.WebPartPages.ContentEditorWebPart</TypeName>
+            </WebPart>";
+
+            var type = PageWebPartExtractor.GetTypeFromXml(v2Xml);
+
+            type.Should().Be("Microsoft.SharePoint.WebPartPages.ContentEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetTypeFromXml_EmptyXml_ReturnsUnknown(string xml)
+        {
+            PageWebPartExtractor.GetTypeFromXml(xml).Should().Be("Unknown");
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageWebPartExtractor.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageWebPartExtractor.cs
@@ -214,6 +214,80 @@ namespace PnP.Scanning.Core.Scanners
             return ToRows(page, ordered, exportWebPartProperties);
         }
 
+        /// <summary>
+        /// Extracts the web part inventory for a publishing page using its <c>LimitedWebPartManager</c>.
+        /// Ported from the legacy <c>PublishingPage.GetWebPartsForScanner</c> (the scanner-oriented variant,
+        /// not the transform-oriented <c>Analyze</c>): it inventories every web part placed in the page's
+        /// web part zones. Unlike <see cref="ExtractFromWebPartPageAsync"/> there is no page-layout / row /
+        /// column mapping (the legacy scanner leaves the layout at <c>PublishingPage_AutoDetect</c> and does
+        /// not position the parts) and no TitleBar exclusion — every web part the manager returns is recorded.
+        /// </summary>
+        /// <remarks>
+        /// SPO-only, matching T5: the on-premises web-services fallback
+        /// (<c>LoadPublishingPageFromWebServices</c> / <c>ExtractWebPartDocumentViaWebServicesFromPage</c>) is
+        /// intentionally not ported. Web parts placed outside a web part zone (e.g. directly in a field control
+        /// via SharePoint Designer) are not surfaced by the web part manager and are therefore not captured,
+        /// matching the legacy scanner behaviour.
+        /// </remarks>
+        /// <param name="csomContext">CSOM context for the web (already throttle-aware).</param>
+        /// <param name="page">The discovered classic page the rows belong to.</param>
+        /// <param name="exportWebPartProperties">When set, the web part properties are serialized to JSON.</param>
+        internal static async Task<List<ClassicPageWebPart>> ExtractFromPublishingPageAsync(ClientContext csomContext, ClassicPage page,
+                                                                                            bool exportWebPartProperties)
+        {
+            var publishingPage = csomContext.Web.GetFileByServerRelativeUrl(page.PageUrl);
+
+            var limitedWPManager = publishingPage.GetLimitedWebPartManager(PersonalizationScope.Shared);
+            csomContext.Load(limitedWPManager);
+
+            var webParts = csomContext.LoadQuery(limitedWPManager.WebParts.IncludeWithDefaultProperties(
+                wp => wp.Id, wp => wp.ZoneId, wp => wp.WebPart.ExportMode, wp => wp.WebPart.Title,
+                wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden, wp => wp.WebPart.Properties));
+            await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+            // Export the web part XML for the parts that allow it (gives the most reliable type).
+            var exportedXml = new Dictionary<Guid, ClientResult<string>>();
+            bool isDirty = false;
+            foreach (var foundWebPart in webParts)
+            {
+                if (foundWebPart.WebPart.ExportMode == WebPartExportMode.All)
+                {
+                    exportedXml[foundWebPart.Id] = limitedWPManager.ExportWebPart(foundWebPart.Id);
+                    isDirty = true;
+                }
+            }
+            if (isDirty)
+            {
+                await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+            }
+
+            var entities = new List<WebPartEntity>();
+            // Process in zone-index order, as the legacy scanner does, so the resulting row order is stable.
+            foreach (var foundWebPart in webParts.OrderBy(wp => wp.WebPart.ZoneIndex))
+            {
+                exportedXml.TryGetValue(foundWebPart.Id, out var xml);
+                string webPartType = xml != null ? GetTypeFromXml(xml.Value) : GetTypeFromProperties(foundWebPart.WebPart.Properties.FieldValues);
+
+                entities.Add(new WebPartEntity
+                {
+                    Title = foundWebPart.WebPart.Title,
+                    Type = webPartType,
+                    Id = foundWebPart.Id,
+                    ServerControlId = foundWebPart.Id.ToString(),
+                    // The legacy scanner does not map publishing zones to a row/column grid (that is layout
+                    // detection, deferred to T7); only the zone index is meaningful here.
+                    Order = foundWebPart.WebPart.ZoneIndex,
+                    ZoneId = foundWebPart.ZoneId,
+                    ZoneIndex = (uint)foundWebPart.WebPart.ZoneIndex,
+                    IsClosed = foundWebPart.WebPart.IsClosed,
+                    Hidden = foundWebPart.WebPart.Hidden,
+                    Properties = ToStringProperties(foundWebPart.WebPart.Properties.FieldValues),
+                });
+            }
+
+            return ToRows(page, entities, exportWebPartProperties);
+        }
+
         private static List<ClassicPageWebPart> ToRows(ClassicPage page, List<WebPartEntity> entities, bool exportWebPartProperties)
         {
             var rows = new List<ClassicPageWebPart>();
@@ -272,7 +346,8 @@ namespace PnP.Scanning.Core.Scanners
         }
 
         // Determines the web part type from its exported XML. Ported from BasePage.GetType.
-        private static string GetTypeFromXml(string webPartXml)
+        // Internal (not private) so the publishing/web-part type detection has its own unit tests.
+        internal static string GetTypeFromXml(string webPartXml)
         {
             string type = "Unknown";
 
@@ -295,7 +370,8 @@ namespace PnP.Scanning.Core.Scanners
 
         // Determines the web part type by detecting it from the available properties. Ported from
         // BasePage.GetTypeFromProperties (online code path; the on-premises legacy branch is not ported).
-        private static string GetTypeFromProperties(IDictionary<string, object> properties)
+        // Internal (not private) so the publishing/web-part type detection has its own unit tests.
+        internal static string GetTypeFromProperties(IDictionary<string, object> properties)
         {
             if (HasAll(properties, "ListUrl", "ListId", "Xsl", "JSLink", "ShowTimelineIfAvailable")) return XsltListViewType;
             if (HasAll(properties, "ListViewXml", "ListName", "ListId", "ViewContentTypeId", "PageType")) return ListViewType;


### PR DESCRIPTION
## What

Adds publishing-page web part extraction to the classic page-scan engine, closing the
second of the two web-part-extraction parity gaps found in the T5 review (T5a closed
wiki embedded media; this closes publishing pages).

Before this change, publishing pages (remediation `CP3`) were discovered and typed but
produced **zero** `ClassicPageWebPart` rows — their web parts were never inventoried.

## Changes

- **`PageWebPartExtractor.ExtractFromPublishingPageAsync(...)`** → `List<ClassicPageWebPart>`,
  ported from the legacy `PublishingPage.GetWebPartsForScanner` (the scanner-oriented variant,
  not the transform-oriented `Analyze`). Walks `LimitedWebPartManager.WebParts`, exports XML for
  `ExportMode.All` parts, types each part, and records ZoneId/ZoneIndex.
- Exposed `GetTypeFromXml` / `GetTypeFromProperties` as `internal` (were `private`) so the
  type-detection sub-logic shared with T5 gets its own unit tests.
- New unit tests in `Tests/Scanners/Pages/PageWebPartExtractorTests.cs`.

## Decisions (consistent with T5)

- **Scanner variant, not `Analyze`:** no page-layout / row-column mapping (Row/Column left at
  default — that's T7's job) and no TitleBar exclusion. Parts iterated in `OrderBy(ZoneIndex)` so
  row order is stable; `Order`/`ZoneIndex` carry the zone index.
- **SPO-only:** the on-prem web-services fallback (`LoadPublishingPageFromWebServices`) is not
  ported, same as T5. Uses `ExecuteQueryAsync()` (no `ExecuteQueryRetry` in this repo).
- Keeps all field values via `ToStringProperties` (T5 abandoned the legacy per-type `Properties()`
  filter); JSON props gated by `ExportWebPartProperties`.
- **Not wired into `PageScanComponent.ExecuteAsync`** — T8 owns the per-web call + bulk persist,
  same deferral as T5/T5a. This PR adds no per-page CSOM work yet.
- Web parts placed outside a web part zone (SPD field controls) are not surfaced by the web part
  manager and are therefore not captured — matches the legacy scanner behaviour.

## Tests

- `GetTypeFromProperties` `[Theory]` over ScriptEditor / XsltListView / Members / Media property
  signatures + the unsupported-type fallback.
- `GetTypeFromXml` for v3, v2, and empty/null XML.
- Full suite green (45 tests).

The `LimitedWebPartManager` round-trip is CSOM-only and is deferred to the integration test (T15) —
that test's web should gain a publishing page to exercise this path end-to-end.

## Depends on / unblocks

Depends on T5 (extractor) and T4 (entity/types). Lands before T8 so the rows get persisted; pairs
with T7's publishing layout work.