### PR TITLE
Classic page layout detection (wiki / web part / publishing)

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageLayoutDetectorTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageLayoutDetectorTests.cs
@@ -1,0 +1,119 @@
+﻿using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners.Pages
+{
+    /// <summary>
+    /// T7 — page layout detection. Pure (no CSOM) parsing of the wiki <c>WikiField</c> HTML, the web part
+    /// page <c>vti_setuppath</c> property string, and the constant publishing-page layout, plus the
+    /// rendering of a <see cref="PageLayout"/> to the short string stored on <c>ClassicPage.Layout</c>.
+    /// One case per representative layout family.
+    /// </summary>
+    public class PageLayoutDetectorTests
+    {
+        // --- Wiki layout: from the layoutsdata span (the primary path) -----------------------------------
+
+        [Theory]
+        // OneColumn needs no width hint.
+        [InlineData("false,false,1", null, PageLayout.Wiki_OneColumn)]
+        // Two columns: the first styled td's width disambiguates equal-width vs sidebar.
+        [InlineData("false,false,2", "width:49.95%;", PageLayout.Wiki_TwoColumns)]
+        [InlineData("false,false,2", "width:66.6%;", PageLayout.Wiki_TwoColumnsWithSidebar)]
+        [InlineData("true,false,2", null, PageLayout.Wiki_TwoColumnsWithHeader)]
+        [InlineData("true,true,2", null, PageLayout.Wiki_TwoColumnsWithHeaderAndFooter)]
+        [InlineData("false,false,3", null, PageLayout.Wiki_ThreeColumns)]
+        [InlineData("true,false,3", null, PageLayout.Wiki_ThreeColumnsWithHeader)]
+        [InlineData("true,true,3", null, PageLayout.Wiki_ThreeColumnsWithHeaderAndFooter)]
+        public void Layout_WikiLayoutsDataSpan_DetectsFamily(string layoutsData, string firstTdStyle, PageLayout expected)
+        {
+            var html = WikiWithLayoutsData(layoutsData, firstTdStyle);
+
+            PageLayoutDetector.DetectWikiLayout(html).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Layout_WikiEmpty_IsOneColumn(string html)
+        {
+            // Parity with the legacy scanner: an empty wiki page is a one-column layout.
+            PageLayoutDetector.DetectWikiLayout(html).Should().Be(PageLayout.Wiki_OneColumn);
+        }
+
+        [Fact]
+        public void Layout_WikiNoLayoutsData_IsCustom()
+        {
+            // No recognizable layout markup at all → custom layout.
+            PageLayoutDetector.DetectWikiLayout("<div><p>free standing wiki content</p></div>")
+                .Should().Be(PageLayout.Wiki_Custom);
+        }
+
+        [Fact]
+        public void Layout_WikiUnrecognizedSpan_FallsBackToColumnCount()
+        {
+            // Some pages (e.g. community-template pages) leave the layoutsdata token unsubstituted; the
+            // fallback then deduces the layout from the styled-column count. "false,false,{0}" with three
+            // styled columns ⇒ three-column layout.
+            var html = WikiWithLayoutsData("false,false,{0}", "width:33%;", "width:33%;", "width:33%;");
+
+            PageLayoutDetector.DetectWikiLayout(html).Should().Be(PageLayout.Wiki_ThreeColumns);
+        }
+
+        // --- Web part page layout: from the vti_setuppath property ---------------------------------------
+
+        [Theory]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd1.aspx", PageLayout.WebPart_FullPageVertical)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd2.aspx", PageLayout.WebPart_HeaderFooterThreeColumns)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd3.aspx", PageLayout.WebPart_HeaderLeftColumnBody)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd4.aspx", PageLayout.WebPart_HeaderRightColumnBody)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd5.aspx", PageLayout.WebPart_HeaderFooter2Columns4Rows)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd6.aspx", PageLayout.WebPart_HeaderFooter4ColumnsTopRow)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd7.aspx", PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns)]
+        [InlineData(@"1033\STS\doctemp\smartpgs\spstd8.aspx", PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns)]
+        [InlineData(@"SiteTemplates\STS\default.aspx", PageLayout.WebPart_2010_TwoColumnsLeft)]
+        public void Layout_WebPartSetupPath_DetectsKnownTemplate(string setupPath, PageLayout expected)
+        {
+            PageLayoutDetector.DetectWebPartPageLayout(setupPath).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(@"1033\STS\doctemp\smartpgs\unknown.aspx")]
+        public void Layout_WebPartUnknownSetupPath_IsCustom(string setupPath)
+        {
+            PageLayoutDetector.DetectWebPartPageLayout(setupPath).Should().Be(PageLayout.WebPart_Custom);
+        }
+
+        // Publishing-page layout is NOT derived here — it is the actual page layout name read from the
+        // PublishingPageLayout field; see PageWebPartExtractorTests.GetPublishingPageLayoutName_*.
+
+        // --- Layout string rendering (what lands on ClassicPage.Layout for wiki / web part pages) --------
+
+        [Theory]
+        [InlineData(PageLayout.Wiki_OneColumn, "OneColumn")]
+        [InlineData(PageLayout.Wiki_TwoColumnsWithSidebar, "TwoColumnsWithSidebar")]
+        [InlineData(PageLayout.WebPart_Custom, "Custom")]
+        [InlineData(PageLayout.WebPart_2010_TwoColumnsLeft, "2010_TwoColumnsLeft")]
+        public void Layout_ToLayoutString_StripsWikiAndWebPartPrefixes(PageLayout layout, string expected)
+        {
+            PageLayoutDetector.ToLayoutString(layout).Should().Be(expected);
+        }
+
+        // Builds a minimal wiki HTML page carrying a layoutsdata span and an optional set of styled
+        // columns (only the first td's style matters to the detector, but the fallback counts all of them).
+        private static string WikiWithLayoutsData(string layoutsData, params string[] tdStyles)
+        {
+            var tds = string.Concat(tdStyles
+                .Where(s => s != null)
+                .Select(s => $"<td style=\"{s}\">&#160;</td>"));
+
+            return $@"<div class=""ExternalClassABC"">
+                        <span id=""layoutsdata"">{layoutsData}</span>
+                        <table id=""layoutsTable""><tbody><tr>{tds}</tr></tbody></table>
+                      </div>";
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageWebPartExtractorTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageWebPartExtractorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.SharePoint.Client;
 using PnP.Scanning.Core.Scanners;
 using Xunit;
 
@@ -88,6 +89,61 @@ namespace PnP.Scanning.Core.Tests.Scanners.Pages
         public void GetTypeFromXml_EmptyXml_ReturnsUnknown(string xml)
         {
             PageWebPartExtractor.GetTypeFromXml(xml).Should().Be("Unknown");
+        }
+
+        // --- T7: publishing page layout name (parity with the legacy PublishingAnalyzer) -----------------
+
+        [Fact]
+        public void GetPublishingPageLayoutName_UrlFieldDescription_ReturnsLayoutName()
+        {
+            // The PublishingPageLayout field is a URL field whose Description holds the friendly layout
+            // name; that name (e.g. "ArticleLeft") is what the legacy scanner records as the page layout.
+            var fieldValues = new Dictionary<string, object>
+            {
+                { "PublishingPageLayout", new FieldUrlValue { Url = "/_catalogs/masterpage/ArticleLeft.aspx", Description = "ArticleLeft" } },
+            };
+
+            PageWebPartExtractor.GetPublishingPageLayoutName(fieldValues).Should().Be("ArticleLeft");
+        }
+
+        [Fact]
+        public void GetPublishingPageLayoutName_FieldMissing_ReturnsEmpty()
+        {
+            var fieldValues = new Dictionary<string, object>
+            {
+                { "SomeOtherField", "value" },
+            };
+
+            PageWebPartExtractor.GetPublishingPageLayoutName(fieldValues).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetPublishingPageLayoutName_NullFieldValue_ReturnsEmpty()
+        {
+            var fieldValues = new Dictionary<string, object>
+            {
+                { "PublishingPageLayout", null },
+            };
+
+            PageWebPartExtractor.GetPublishingPageLayoutName(fieldValues).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetPublishingPageLayoutName_EmptyDescription_ReturnsEmpty()
+        {
+            // A URL field that carries a Url but no Description yields no usable layout name.
+            var fieldValues = new Dictionary<string, object>
+            {
+                { "PublishingPageLayout", new FieldUrlValue { Url = "/_catalogs/masterpage/ArticleLeft.aspx", Description = "" } },
+            };
+
+            PageWebPartExtractor.GetPublishingPageLayoutName(fieldValues).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetPublishingPageLayoutName_NullFieldValues_ReturnsEmpty()
+        {
+            PageWebPartExtractor.GetPublishingPageLayoutName(null).Should().BeEmpty();
         }
     }
 }

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageLayoutDetector.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageLayoutDetector.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
+
+namespace PnP.Scanning.Core.Scanners
+{
+    /// <summary>
+    /// Derives the <see cref="PageLayout"/> of a classic page from its structure, and renders that layout
+    /// to the short string stored on <c>ClassicPage.Layout</c>. Three sources, mirroring the legacy
+    /// Modernization Scanner:
+    /// <list type="bullet">
+    /// <item><description><b>Wiki pages</b> — parsed from the <c>WikiField</c> HTML (the <c>layoutsdata</c>
+    /// span plus a column-count fallback). Ported from <c>WikiPage.GetLayout</c>; pure, no CSOM.</description></item>
+    /// <item><description><b>Web part pages</b> — derived from the page file's <c>vti_setuppath</c>
+    /// property. Ported from <c>WebPartPage.GetLayout</c>; the pure string→layout mapping lives here so it
+    /// is unit-testable (the CSOM property read stays in <see cref="PageWebPartExtractor"/>).</description></item>
+    /// </list>
+    /// The string form matches the legacy page CSV: the enum name with the <c>Wiki_</c> / <c>WebPart_</c>
+    /// prefix stripped (e.g. <c>Wiki_TwoColumns</c> → <c>TwoColumns</c>, <c>WebPart_Custom</c> →
+    /// <c>Custom</c>).
+    /// <para>
+    /// <b>Publishing pages</b> are handled differently and not here: the legacy <c>PublishingAnalyzer</c>
+    /// records the actual page layout <i>name</i> (e.g. <c>ArticleLeft</c>) from the page's
+    /// <c>PublishingPageLayout</c> field, not a derived <see cref="PageLayout"/> enum value. That field read
+    /// lives in <see cref="PageWebPartExtractor.GetPublishingPageLayoutName"/>.
+    /// </para>
+    /// </summary>
+    internal static class PageLayoutDetector
+    {
+        /// <summary>
+        /// Detects the wiki page layout from its <c>WikiField</c> HTML. An empty/whitespace page is a
+        /// one-column layout (parity with the legacy scanner). Ported verbatim from
+        /// <c>WikiPage.GetLayout</c>: read the <c>layoutsdata</c> span, then fall back to counting the
+        /// layout-table columns for pages (e.g. community-template pages) that omit a recognized span value.
+        /// </summary>
+        internal static PageLayout DetectWikiLayout(string wikiFieldHtml)
+        {
+            if (string.IsNullOrEmpty(wikiFieldHtml))
+            {
+                return PageLayout.Wiki_OneColumn;
+            }
+
+            var parser = new HtmlParser();
+            var doc = parser.ParseDocument(wikiFieldHtml);
+
+            string spanValue = "";
+            var spanTags = doc.All.Where(p => p.LocalName == "span" && p.HasAttribute("id"));
+            foreach (var span in spanTags)
+            {
+                if (span.GetAttribute("id").Equals("layoutsdata", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    spanValue = span.InnerHtml.ToLower();
+
+                    if (spanValue == "false,false,1")
+                    {
+                        return PageLayout.Wiki_OneColumn;
+                    }
+                    else if (spanValue == "false,false,2")
+                    {
+                        var tdTag = doc.All.FirstOrDefault(p => p.LocalName == "td" && p.HasAttribute("style"));
+                        if (tdTag != null)
+                        {
+                            if (tdTag.GetAttribute("style").IndexOf("width:49.95%;", StringComparison.InvariantCultureIgnoreCase) > -1)
+                            {
+                                return PageLayout.Wiki_TwoColumns;
+                            }
+                            else if (tdTag.GetAttribute("style").IndexOf("width:66.6%;", StringComparison.InvariantCultureIgnoreCase) > -1)
+                            {
+                                return PageLayout.Wiki_TwoColumnsWithSidebar;
+                            }
+                            else
+                            {
+                                return PageLayout.Wiki_TwoColumns;
+                            }
+                        }
+                    }
+                    else if (spanValue == "true,false,2")
+                    {
+                        return PageLayout.Wiki_TwoColumnsWithHeader;
+                    }
+                    else if (spanValue == "true,true,2")
+                    {
+                        return PageLayout.Wiki_TwoColumnsWithHeaderAndFooter;
+                    }
+                    else if (spanValue == "false,false,3")
+                    {
+                        return PageLayout.Wiki_ThreeColumns;
+                    }
+                    else if (spanValue == "true,false,3")
+                    {
+                        return PageLayout.Wiki_ThreeColumnsWithHeader;
+                    }
+                    else if (spanValue == "true,true,3")
+                    {
+                        return PageLayout.Wiki_ThreeColumnsWithHeaderAndFooter;
+                    }
+                }
+            }
+
+            // Oops, we're still here...let's try to deduct a layout as some pages (e.g. from community
+            // template) do not add the proper span value.
+            if (spanValue.StartsWith("false,false,") || spanValue.StartsWith("true,true,") || spanValue.StartsWith("true,false,"))
+            {
+                var tdTags = doc.All.Where(p => p.LocalName == "td" && p.HasAttribute("style"));
+                if (spanValue.StartsWith("false,false,"))
+                {
+                    if (tdTags.Count() == 1)
+                    {
+                        return PageLayout.Wiki_OneColumn;
+                    }
+                    else if (tdTags.Count() == 2)
+                    {
+                        if (tdTags.First().GetAttribute("style").IndexOf("width:49.95%;", StringComparison.InvariantCultureIgnoreCase) > -1)
+                        {
+                            return PageLayout.Wiki_TwoColumns;
+                        }
+                        else if (tdTags.First().GetAttribute("style").IndexOf("width:66.6%;", StringComparison.InvariantCultureIgnoreCase) > -1)
+                        {
+                            return PageLayout.Wiki_TwoColumnsWithSidebar;
+                        }
+                        else
+                        {
+                            return PageLayout.Wiki_TwoColumns;
+                        }
+                    }
+                    else if (tdTags.Count() == 3)
+                    {
+                        return PageLayout.Wiki_ThreeColumns;
+                    }
+                }
+                else if (spanValue.StartsWith("true,true,"))
+                {
+                    if (tdTags.Count() == 2)
+                    {
+                        return PageLayout.Wiki_TwoColumnsWithHeaderAndFooter;
+                    }
+                    else if (tdTags.Count() == 3)
+                    {
+                        return PageLayout.Wiki_ThreeColumnsWithHeaderAndFooter;
+                    }
+                }
+                else if (spanValue.StartsWith("true,false,"))
+                {
+                    if (tdTags.Count() == 2)
+                    {
+                        return PageLayout.Wiki_TwoColumnsWithHeader;
+                    }
+                    else if (tdTags.Count() == 3)
+                    {
+                        return PageLayout.Wiki_ThreeColumnsWithHeader;
+                    }
+                }
+            }
+
+            return PageLayout.Wiki_Custom;
+        }
+
+        /// <summary>
+        /// Detects the web part page layout from the page file's <c>vti_setuppath</c> value. Ported from
+        /// <c>WebPartPage.GetLayout</c>: each built-in smart-page template maps to a known multi-zone
+        /// layout; everything else (including a null/empty setup path) is a custom layout.
+        /// </summary>
+        /// <param name="setupPath">The <c>vti_setuppath</c> page property value, or null if absent.</param>
+        internal static PageLayout DetectWebPartPageLayout(string setupPath)
+        {
+            if (!string.IsNullOrEmpty(setupPath))
+            {
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd1.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_FullPageVertical;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd2.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooterThreeColumns;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd3.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderLeftColumnBody;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd4.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderRightColumnBody;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd5.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooter2Columns4Rows;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd6.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooter4ColumnsTopRow;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd7.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns;
+                if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd8.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns;
+                if (setupPath.Equals(@"SiteTemplates\STS\default.aspx", StringComparison.InvariantCultureIgnoreCase)) return PageLayout.WebPart_2010_TwoColumnsLeft;
+            }
+
+            return PageLayout.WebPart_Custom;
+        }
+
+        /// <summary>
+        /// Renders a <see cref="PageLayout"/> to the short string persisted on <c>ClassicPage.Layout</c>,
+        /// matching the legacy scanner's page CSV (the <c>Wiki_</c> / <c>WebPart_</c> prefix is dropped).
+        /// </summary>
+        internal static string ToLayoutString(PageLayout layout)
+        {
+            return layout.ToString().Replace("Wiki_", "").Replace("WebPart_", "");
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageWebPartExtractor.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageWebPartExtractor.cs
@@ -43,6 +43,10 @@ namespace PnP.Scanning.Core.Scanners
 
         private const string UnsupportedWebPartType = "Unsupported Web Part Type";
 
+        // The publishing page list item field that holds the page layout reference (a URL field whose
+        // Description is the layout's friendly name). Ported from the legacy Constants.PublishingPageLayoutField.
+        private const string PublishingPageLayoutField = "PublishingPageLayout";
+
         /// <summary>
         /// Extracts the web part inventory for a web part page using its <c>LimitedWebPartManager</c>.
         /// </summary>
@@ -67,6 +71,7 @@ namespace PnP.Scanning.Core.Scanners
             await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
 
             var layout = GetWebPartPageLayout(pageProperties);
+            page.Layout = PageLayoutDetector.ToLayoutString(layout);
 
             // Export the web part XML for the parts that allow it (gives the most reliable type).
             var exportedXml = new Dictionary<Guid, ClientResult<string>>();
@@ -133,6 +138,9 @@ namespace PnP.Scanning.Core.Scanners
         {
             // Pure HTML parsing: text blocks + embedded media parts + placeholders for the embedded web parts.
             var parsed = WikiContentParser.Parse(wikiFieldHtml);
+
+            // The wiki layout is derived from the same HTML (no CSOM needed).
+            page.Layout = PageLayoutDetector.ToLayoutString(PageLayoutDetector.DetectWikiLayout(wikiFieldHtml));
 
             var entities = new List<WebPartEntity>(parsed.TextParts);
             entities.AddRange(parsed.MediaParts);
@@ -218,9 +226,11 @@ namespace PnP.Scanning.Core.Scanners
         /// Extracts the web part inventory for a publishing page using its <c>LimitedWebPartManager</c>.
         /// Ported from the legacy <c>PublishingPage.GetWebPartsForScanner</c> (the scanner-oriented variant,
         /// not the transform-oriented <c>Analyze</c>): it inventories every web part placed in the page's
-        /// web part zones. Unlike <see cref="ExtractFromWebPartPageAsync"/> there is no page-layout / row /
-        /// column mapping (the legacy scanner leaves the layout at <c>PublishingPage_AutoDetect</c> and does
-        /// not position the parts) and no TitleBar exclusion — every web part the manager returns is recorded.
+        /// web part zones. Unlike <see cref="ExtractFromWebPartPageAsync"/> the web parts are not assigned a
+        /// row / column (the legacy scanner does not position publishing-page parts) and there is no TitleBar
+        /// exclusion — every web part the manager returns is recorded. The page's <c>Layout</c> is set to the
+        /// actual page layout name (e.g. <c>ArticleLeft</c>) read from the <c>PublishingPageLayout</c> field,
+        /// matching the legacy <c>PublishingAnalyzer</c> (see <see cref="GetPublishingPageLayoutName"/>).
         /// </summary>
         /// <remarks>
         /// SPO-only, matching T5: the on-premises web-services fallback
@@ -237,6 +247,10 @@ namespace PnP.Scanning.Core.Scanners
         {
             var publishingPage = csomContext.Web.GetFileByServerRelativeUrl(page.PageUrl);
 
+            // The publishing page's list item carries the page layout reference we report as the layout.
+            var listItem = publishingPage.ListItemAllFields;
+            csomContext.Load(listItem);
+
             var limitedWPManager = publishingPage.GetLimitedWebPartManager(PersonalizationScope.Shared);
             csomContext.Load(limitedWPManager);
 
@@ -244,6 +258,11 @@ namespace PnP.Scanning.Core.Scanners
                 wp => wp.Id, wp => wp.ZoneId, wp => wp.WebPart.ExportMode, wp => wp.WebPart.Title,
                 wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden, wp => wp.WebPart.Properties));
             await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+            // Parity with the legacy PublishingAnalyzer: the recorded layout is the actual page layout name
+            // (e.g. "ArticleLeft") read from the PublishingPageLayout field — not the transform engine's
+            // PublishingPage_AutoDetect placeholder (which the legacy scanner discards for publishing pages).
+            page.Layout = GetPublishingPageLayoutName(listItem.FieldValues);
 
             // Export the web part XML for the parts that allow it (gives the most reliable type).
             var exportedXml = new Dictionary<Guid, ClientResult<string>>();
@@ -387,6 +406,25 @@ namespace PnP.Scanning.Core.Scanners
             return UnsupportedWebPartType;
         }
 
+        // Reads the publishing page layout name from the page list item's PublishingPageLayout field.
+        // Ported verbatim from the legacy ListItemExtensions.PageLayout: the field is a URL field whose
+        // Description is the friendly layout name (e.g. "ArticleLeft"); an absent/empty field yields "".
+        // Internal (not private) so the field-value parsing has its own unit tests; the CSOM list item load
+        // is integration-only.
+        internal static string GetPublishingPageLayoutName(IDictionary<string, object> fieldValues)
+        {
+            if (fieldValues != null &&
+                fieldValues.TryGetValue(PublishingPageLayoutField, out var value) &&
+                value != null &&
+                !string.IsNullOrEmpty(value.ToString()))
+            {
+                var description = (value as FieldUrlValue)?.Description;
+                return string.IsNullOrEmpty(description) ? "" : description;
+            }
+
+            return "";
+        }
+
         private static bool HasAll(IDictionary<string, object> properties, params string[] keys)
         {
             foreach (var key in keys)
@@ -400,28 +438,16 @@ namespace PnP.Scanning.Core.Scanners
             return true;
         }
 
-        // Determines the web part page layout from the page file properties. Ported from
-        // WebPartPage.GetLayout.
+        // Determines the web part page layout from the page file properties. Reads the vti_setuppath
+        // property (CSOM) and delegates the actual string→layout mapping to the pure PageLayoutDetector
+        // (ported from WebPartPage.GetLayout) so that logic is unit-testable on its own.
         private static PageLayout GetWebPartPageLayout(PropertyValues pageProperties)
         {
-            if (pageProperties.FieldValues.ContainsKey("vti_setuppath"))
-            {
-                var setupPath = pageProperties["vti_setuppath"]?.ToString();
-                if (!string.IsNullOrEmpty(setupPath))
-                {
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd1.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_FullPageVertical;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd2.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooterThreeColumns;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd3.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderLeftColumnBody;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd4.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderRightColumnBody;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd5.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooter2Columns4Rows;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd6.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_HeaderFooter4ColumnsTopRow;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd7.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns;
-                    if (setupPath.IndexOf(@"\STS\doctemp\smartpgs\spstd8.aspx", StringComparison.InvariantCultureIgnoreCase) > -1) return PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns;
-                    if (setupPath.Equals(@"SiteTemplates\STS\default.aspx", StringComparison.InvariantCultureIgnoreCase)) return PageLayout.WebPart_2010_TwoColumnsLeft;
-                }
-            }
+            var setupPath = pageProperties.FieldValues.ContainsKey("vti_setuppath")
+                ? pageProperties["vti_setuppath"]?.ToString()
+                : null;
 
-            return PageLayout.WebPart_Custom;
+            return PageLayoutDetector.DetectWebPartPageLayout(setupPath);
         }
 
         // Translates the given zone value and page layout to a column number. Ported from WebPartPage.GetColumn.


### PR DESCRIPTION
## What

Adds page-layout detection to the classic page scan, populating `ClassicPage.Layout`.
Part of the Modernization Scanner → Microsoft 365 Assessment tool consolidation
(implements **T7** of the classic-page-scan backlog).

## Why

The `Layout` column on `ClassicPage` (added in T1) was never populated. The legacy
Modernization Scanner records a page layout for every classic page; this carries that
capability forward so the assessment output reports the same layout information.

## Changes

**New — `Scanners/Classic/Pages/PageLayoutDetector.cs`** (pure, no CSOM):
- `DetectWikiLayout(wikiFieldHtml)` — ported verbatim from `WikiPage.GetLayout`: reads the
  `layoutsdata` span (one/two/three-column families, the `49.95%` vs `66.6%` two-column-vs-sidebar
  split) plus the community-template fallback that counts styled `<td>` columns. Empty ⇒
  `Wiki_OneColumn`, unrecognized ⇒ `Wiki_Custom`.
- `DetectWebPartPageLayout(setupPath)` — the pure `vti_setuppath` → layout mapping lifted out of
  `PageWebPartExtractor` (eight `spstdN.aspx` smart-page templates + the 2010 default; else
  `WebPart_Custom`), ported from `WebPartPage.GetLayout`.
- `ToLayoutString(layout)` — renders to the short string the legacy page CSV used:
  `Replace("Wiki_","").Replace("WebPart_","")`.

**Modified — `Scanners/Classic/Pages/PageWebPartExtractor.cs`:**
- Each of the three extract methods now sets `page.Layout`:
  - wiki — from the `WikiField` HTML,
  - web part page — from the `vti_setuppath` layout it already computes for row/column mapping,
  - publishing — from the **actual page layout name** (e.g. `ArticleLeft`) read from the
    `PublishingPageLayout` field via the new `GetPublishingPageLayoutName(...)`, matching the legacy
    `PublishingAnalyzer`. (Notably **not** the `PublishingPage_AutoDetect` enum — that's an internal
    transform-engine value the legacy scanner discards for publishing pages.)
- `GetWebPartPageLayout(PropertyValues)` refactored to read the CSOM property and delegate to the pure
  detector.

## Parity notes

Verified line-by-line against `WikiPage.GetLayout`, `WebPartPage.GetLayout`, `PublishingAnalyzer` +
`ListItemExtensions.PageLayout`, and the `PageAnalyzer` CSV render.

- **Layout applies to wiki / web part / publishing pages only.** Blog, Delve-blog, and ASPX pages get
  no layout — matching the legacy scanner, which recorded blogs as a metadata-only result with no layout
  or web parts (the `isBlogPage` BodyField layout path is transformer code, out of scope for scan-only).
- **SPO-only** (consistent with T5): the on-prem `WebPartPageOnPremises.GetLayoutFromWebServices` variant
  is intentionally not ported.
- `ClassicPage.Layout` already exists from T1 — **no migration**.
- Not yet wired into `PageScanComponent.ExecuteAsync` — T8 owns the per-web extractor call + persist
  (same deferral as T5/T5a/T5b/T6).

## Tests

- `PageLayoutDetectorTests.cs` — wiki span families + empty + custom + column-count fallback; all nine
  web-part setup-path templates + unknown/empty → Custom; `ToLayoutString` prefix-stripping.
- `PageWebPartExtractorTests.cs` (+5) — `GetPublishingPageLayoutName`: URL-field Description,
  missing/null field, empty description, null dict.
- Full suite green: **84 passed, 0 failed**. The `LimitedWebPartManager` / list-item CSOM reads are
  integration-only (→ T15).