### PR TITLE
Classic page scan (T10): home page + uncustomized home page detection

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/HomePageDetectorTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/HomePageDetectorTests.cs
@@ -1,0 +1,279 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners.Pages
+{
+    /// <summary>
+    /// T10 — home-page semantics. The pure pieces are exercised here directly (no CSOM, no live
+    /// SharePoint):
+    /// <list type="bullet">
+    /// <item><description><see cref="HomePageDetector.IsHomePage"/> — the welcome-page url compare.</description></item>
+    /// <item><description><see cref="HomePageDetector.IsHtmlUncustomized"/> — the default-home-page HTML
+    /// compare (the fallback used when the CSOM <c>CanModernizeHomepage</c> API is unavailable).</description></item>
+    /// <item><description><see cref="HomePageDetector.IsDefaultTeamSiteWebPartSet"/> and
+    /// <see cref="HomePageDetector.IsUncustomizedHomePageFallback"/> — the rest of the fallback decision.</description></item>
+    /// </list>
+    /// The reliable CSOM <c>web.CanModernizeHomepage</c> path (a bare property read) is wired per-web with
+    /// the rest of the page scan and is covered by the integration test (T15).
+    /// </summary>
+    public class HomePageDetectorTests
+    {
+        // Short type names the legacy categorization keys on, expanded to fully assembly-qualified types
+        // (TypeShort() drops everything after the first comma, recovering the short name).
+        private const string XsltListViewType = "Microsoft.SharePoint.WebPartPages.XsltListViewWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ListViewType = "Microsoft.SharePoint.WebPartPages.ListViewWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string GettingStartedType = "Microsoft.SharePoint.WebPartPages.GettingStartedWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string SiteFeedType = "Microsoft.SharePoint.Portal.WebControls.SiteFeedWebPart, Microsoft.SharePoint.Portal, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ContentEditorType = "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+
+        // Captured default team-site home page WikiField HTML: the normalized out-of-the-box layout with
+        // realistic whitespace and per-web-part GUIDs (both stripped during the uncustomized compare).
+        // "DefaultHtml" = SiteFeed + XsltListView + GettingStarted; "DefaultRootHtml" = the root site variant.
+        private const string DefaultHomeHtml = "<divclass=\"<tableid=\"layoutsTable\"style=\"width&#58;100%;\">\n            <tbody>\n            <trstyle=\"vertical-align&#58;top;\">\n            <tdcolspan=\"2\">\n            <divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\">\n            <divclass=\"ms-rte-layoutszone-inner\"style=\"word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\">\n            <divclass=\"ms-rtestate-readms-rte-wpbox\">\n            <divclass=\"ms-rtestate-read\"id=\"div_CCCCCCCC-1111-2222-3333-444444444444\">\n            </div>\n            <divclass=\"ms-rtestate-read\"id=\"vid_DDDDDDDD-1111-2222-3333-444444444444\"style=\"display&#58;none;\">\n            </div>\n            </div>\n            </div>\n            </div>\n            </td>\n            </tr>\n            <trstyle=\"vertical-align&#58;top;\">\n            <tdstyle=\"width&#58;49.95%;\">\n            <divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\">\n            <divclass=\"ms-rte-layoutszone-inner\"style=\"word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\">\n            <divclass=\"ms-rtestate-readms-rte-wpbox\">\n            <divclass=\"ms-rtestate-read\"id=\"div_CCCCCCCC-1111-2222-3333-444444444444\">\n            </div>\n            <divclass=\"ms-rtestate-read\"id=\"vid_DDDDDDDD-1111-2222-3333-444444444444\"style=\"display&#58;none;\">\n            </div>\n            </div>\n            </div>\n            </div>\n            </td>\n            <tdclass=\"ms-wiki-columnSpacing\"style=\"width&#58;49.95%;\">\n            <divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\">\n            <divclass=\"ms-rte-layoutszone-inner\"style=\"word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\">\n            <divclass=\"ms-rtestate-readms-rte-wpbox\">\n            <divclass=\"ms-rtestate-read\"id=\"div_CCCCCCCC-1111-2222-3333-444444444444\">\n            </div>\n            <divclass=\"ms-rtestate-read\"id=\"vid_DDDDDDDD-1111-2222-3333-444444444444\"style=\"display&#58;none;\">\n            </div>\n            </div>\n            </div>\n            </div>\n            </td>\n            </tr>\n            </tbody>\n            </table>\n            <spanid=\"layoutsData\"style=\"display&#58;none;\">true,false,2</span>\n            </div>";
+
+        private const string DefaultRootHomeHtml = "<divclass=\"<tableid=\"layoutsTable\"style=\"width&#58;100%;\">\n            <tbody>\n            <trstyle=\"vertical-align&#58;top;\">\n            <tdstyle=\"width&#58;100%;padding&#58;0px;\">\n            <divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\">\n            <divclass=\"ms-rte-layoutszone-inner\"style=\"min-height&#58;60px;word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\">\n            <divclass=\"ms-rtestate-readms-rte-wpbox\">\n            <divclass=\"ms-rtestate-read\"id=\"div_AAAAAAAA-1111-2222-3333-444444444444\">\n            </div>\n            <divclass=\"ms-rtestate-read\"id=\"vid_BBBBBBBB-1111-2222-3333-444444444444\"style=\"display&#58;none;\">\n            </div>\n            </div>\n            <divclass=\"ms-rtestate-readms-rte-wpbox\">\n            <divclass=\"ms-rtestate-read\"id=\"div_AAAAAAAA-1111-2222-3333-444444444444\">\n            </div>\n            <divclass=\"ms-rtestate-read\"id=\"vid_BBBBBBBB-1111-2222-3333-444444444444\"style=\"display&#58;none;\">\n            </div>\n            </div>\n            </div>\n            </div>\n            </td>\n            </tr>\n            </tbody>\n            </table>\n            <spanid=\"layoutsData\"style=\"display&#58;none;\">false,false,1</span>\n            </div>";
+
+        private static WebPartEntity WebPart(string fullType)
+        {
+            return new WebPartEntity { Type = fullType };
+        }
+
+        #region IsHomePage
+
+        [Fact]
+        public void HomePage_UrlEqualsWelcomePage_True()
+        {
+            HomePageDetector.IsHomePage("/sites/team/SitePages/Home.aspx", "SitePages/Home.aspx").Should().BeTrue();
+        }
+
+        [Fact]
+        public void HomePage_DifferentUrl_False()
+        {
+            HomePageDetector.IsHomePage("/sites/team/SitePages/About.aspx", "SitePages/Home.aspx").Should().BeFalse();
+        }
+
+        [Fact]
+        public void HomePage_IsCaseInsensitive()
+        {
+            HomePageDetector.IsHomePage("/sites/team/SitePages/HOME.ASPX", "SitePages/Home.aspx").Should().BeTrue();
+        }
+
+        [Fact]
+        public void HomePage_EmptyWelcomePage_DefaultsToDefaultAspx()
+        {
+            // A web with no welcome page (e.g. a web part page home page) defaults to default.aspx.
+            HomePageDetector.IsHomePage("/sites/team/default.aspx", "").Should().BeTrue();
+            HomePageDetector.IsHomePage("/sites/team/default.aspx", null).Should().BeTrue();
+            HomePageDetector.IsHomePage("/sites/team/SitePages/Home.aspx", "").Should().BeFalse();
+        }
+
+        [Fact]
+        public void HomePage_NullPageUrl_False()
+        {
+            HomePageDetector.IsHomePage(null, "SitePages/Home.aspx").Should().BeFalse();
+        }
+
+        [Fact]
+        public void NormalizeWelcomePage_EmptyOrNull_ReturnsDefaultAspx()
+        {
+            HomePageDetector.NormalizeWelcomePage("").Should().Be("default.aspx");
+            HomePageDetector.NormalizeWelcomePage(null).Should().Be("default.aspx");
+            HomePageDetector.NormalizeWelcomePage("SitePages/Home.aspx").Should().Be("SitePages/Home.aspx");
+        }
+
+        #endregion
+
+        #region IsHtmlUncustomized
+
+        [Fact]
+        public void UncustomizedHome_DefaultStsHtml_True()
+        {
+            HomePageDetector.IsHtmlUncustomized(DefaultHomeHtml).Should().BeTrue();
+        }
+
+        [Fact]
+        public void UncustomizedHome_DefaultRootStsHtml_True()
+        {
+            HomePageDetector.IsHtmlUncustomized(DefaultRootHomeHtml).Should().BeTrue();
+        }
+
+        [Fact]
+        public void UncustomizedHome_CustomizedHtml_False()
+        {
+            // The same default layout with an added paragraph of real content no longer matches.
+            var customized = DefaultHomeHtml.Replace("<tbody>", "<tbody><p>Welcome to our customized team site!</p>");
+            HomePageDetector.IsHtmlUncustomized(customized).Should().BeFalse();
+        }
+
+        [Fact]
+        public void UncustomizedHome_NullOrEmptyHtml_False()
+        {
+            HomePageDetector.IsHtmlUncustomized(null).Should().BeFalse();
+            HomePageDetector.IsHtmlUncustomized("").Should().BeFalse();
+        }
+
+        #endregion
+
+        #region IsDefaultTeamSiteWebPartSet
+
+        [Fact]
+        public void DefaultWebPartSet_SingleXsltListViewPlusDefaults_True()
+        {
+            // The out-of-the-box team site home page: a single XsltListView plus the getting-started/feed parts.
+            var webParts = new List<WebPartEntity>
+            {
+                WebPart(GettingStartedType),
+                WebPart(SiteFeedType),
+                WebPart(XsltListViewType),
+            };
+
+            HomePageDetector.IsDefaultTeamSiteWebPartSet(webParts).Should().BeTrue();
+        }
+
+        [Fact]
+        public void DefaultWebPartSet_NoListViews_False()
+        {
+            // The list view web part was removed → no longer the default set.
+            var webParts = new List<WebPartEntity>
+            {
+                WebPart(GettingStartedType),
+            };
+
+            HomePageDetector.IsDefaultTeamSiteWebPartSet(webParts).Should().BeFalse();
+        }
+
+        [Fact]
+        public void DefaultWebPartSet_MultipleListViews_False()
+        {
+            var webParts = new List<WebPartEntity>
+            {
+                WebPart(XsltListViewType),
+                WebPart(XsltListViewType),
+                WebPart(ListViewType),
+            };
+
+            HomePageDetector.IsDefaultTeamSiteWebPartSet(webParts).Should().BeFalse();
+        }
+
+        [Fact]
+        public void DefaultWebPartSet_ContainsOtherWebPart_False()
+        {
+            var webParts = new List<WebPartEntity>
+            {
+                WebPart(XsltListViewType),
+                WebPart(ContentEditorType),
+            };
+
+            HomePageDetector.IsDefaultTeamSiteWebPartSet(webParts).Should().BeFalse();
+        }
+
+        [Fact]
+        public void DefaultWebPartSet_NullOrEmpty_False()
+        {
+            // No web parts at all is not the default set (it requires exactly one XsltListView).
+            HomePageDetector.IsDefaultTeamSiteWebPartSet(null).Should().BeFalse();
+            HomePageDetector.IsDefaultTeamSiteWebPartSet(new List<WebPartEntity>()).Should().BeFalse();
+        }
+
+        #endregion
+
+        #region IsUncustomizedHomePageFallback
+
+        private static List<WebPartEntity> DefaultHomeWebParts() => new()
+        {
+            WebPart(GettingStartedType),
+            WebPart(XsltListViewType),
+        };
+
+        // Builds the fallback call with all conditions satisfied; each test overrides one input to flip it.
+        private static bool Evaluate(
+            bool isHomePage = true,
+            string webTemplate = "STS",
+            int webConfiguration = 0,
+            bool publishingSiteFeatureEnabled = false,
+            bool publishingWebFeatureEnabled = false,
+            bool homePageModernizationOptedOut = false,
+            bool siteWasGroupified = false,
+            string masterUrl = "https://contoso.sharepoint.com/sites/team/_catalogs/masterpage/seattle.master",
+            string pageName = "Home.aspx",
+            string localizedHomePageName = "Home.aspx",
+            string wikiHtml = DefaultHomeHtml,
+            List<WebPartEntity> webParts = null,
+            string contentTypeDisplayFormTemplateName = "WikiEditForm")
+        {
+            return HomePageDetector.IsUncustomizedHomePageFallback(
+                isHomePage, webTemplate, webConfiguration, publishingSiteFeatureEnabled, publishingWebFeatureEnabled,
+                homePageModernizationOptedOut, siteWasGroupified, masterUrl, pageName, localizedHomePageName,
+                wikiHtml, webParts ?? DefaultHomeWebParts(), contentTypeDisplayFormTemplateName);
+        }
+
+        [Fact]
+        public void Fallback_DefaultStsHomePage_True()
+        {
+            Evaluate().Should().BeTrue();
+        }
+
+        [Fact]
+        public void Fallback_NotHomePage_False()
+        {
+            Evaluate(isHomePage: false).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_NotStsTeamSite_False()
+        {
+            Evaluate(webTemplate: "SITEPAGEPUBLISHING").Should().BeFalse();
+            Evaluate(webConfiguration: 1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_PublishingOrOptedOut_False()
+        {
+            Evaluate(publishingSiteFeatureEnabled: true).Should().BeFalse();
+            Evaluate(publishingWebFeatureEnabled: true).Should().BeFalse();
+            Evaluate(homePageModernizationOptedOut: true).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_Groupified_False()
+        {
+            Evaluate(siteWasGroupified: true).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_NonDefaultMasterPage_False()
+        {
+            Evaluate(masterUrl: "https://contoso.sharepoint.com/sites/team/_catalogs/masterpage/custom.master").Should().BeFalse();
+            Evaluate(masterUrl: null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_NotTheDefaultHomePageName_False()
+        {
+            Evaluate(pageName: "Welcome.aspx").Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_CustomizedHtml_False()
+        {
+            Evaluate(wikiHtml: "<div>totally custom content</div>").Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_NonDefaultWebPartSet_False()
+        {
+            Evaluate(webParts: new List<WebPartEntity> { WebPart(ContentEditorType) }).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Fallback_NotWikiEditFormContentType_False()
+        {
+            Evaluate(contentTypeDisplayFormTemplateName: "CustomEditForm").Should().BeFalse();
+        }
+
+        #endregion
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/HomePageDetector.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/HomePageDetector.cs
@@ -1,0 +1,229 @@
+﻿using System.Text.RegularExpressions;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
+
+namespace PnP.Scanning.Core.Scanners
+{
+    /// <summary>
+    /// Home-page semantics for a discovered classic page, ported from the Modernization Scanner's
+    /// <c>PageAnalyzer</c>:
+    /// <list type="bullet">
+    /// <item><description><b>Home page</b> — whether the page is the web's welcome page
+    /// (<see cref="IsHomePage"/>, a pure compare against <c>web.WelcomePage</c>).</description></item>
+    /// <item><description><b>Uncustomized home page</b> — whether the page is a still-default
+    /// "out of the box" team-site home page. The reliable answer comes from the CSOM
+    /// <c>web.CanModernizeHomepage</c> API (a bare property read, so it has no logic to port — it is
+    /// part of the per-web CSOM wiring assembled in the persistence task and exercised by the
+    /// integration test). When that API is unavailable the legacy scanner falls back to an
+    /// HTML/web-part heuristic, which <i>does</i> carry logic; that whole fallback decision is ported
+    /// here as the pure <see cref="IsUncustomizedHomePageFallback"/> so it is unit-testable.</description></item>
+    /// </list>
+    /// Everything in this module is pure (no CSOM): the caller resolves the CSOM inputs (welcome page,
+    /// feature flags, master page url, content type, localized home-page name) and passes them in.
+    /// </summary>
+    internal static class HomePageDetector
+    {
+        // Default welcome page name used when web.WelcomePage is empty (e.g. a web part page home page),
+        // matching the legacy PageAnalyzer.
+        internal const string DefaultWelcomePage = "default.aspx";
+
+        // The default master page url suffix an uncustomized team site still points at.
+        private const string SeattleMasterSuffix = "_catalogs/masterpage/seattle.master";
+
+        // The content type display form template name an uncustomized wiki home page still uses.
+        private const string WikiEditForm = "WikiEditForm";
+
+        // Web part type (short) names used to categorize a team-site home page's default web part set.
+        private const string GettingStartedWebPart = "Microsoft.SharePoint.WebPartPages.GettingStartedWebPart";
+        private const string SiteFeedWebPart = "Microsoft.SharePoint.Portal.WebControls.SiteFeedWebPart";
+        private const string XsltListViewWebPart = "Microsoft.SharePoint.WebPartPages.XsltListViewWebPart";
+        private const string ListViewWebPart = "Microsoft.SharePoint.WebPartPages.ListViewWebPart";
+
+        // Root site home page with XsltListViewWebPart and GettingStartedWebPart (normalized form).
+        // Verbatim from the legacy PageAnalyzer.DefaultRootHtml.
+        private const string DefaultRootHtml = "<divclass=\"<tableid=\"layoutsTable\"style=\"width&#58;100%;\"><tbody><trstyle=\"vertical-align&#58;top;\"><tdstyle=\"width&#58;100%;padding&#58;0px;\"><divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\"><divclass=\"ms-rte-layoutszone-inner\"style=\"min-height&#58;60px;word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\"><divclass=\"ms-rtestate-readms-rte-wpbox\"><divclass=\"ms-rtestate-read\"id=\"div_\"></div><divclass=\"ms-rtestate-read\"id=\"vid_\"style=\"display&#58;none;\"></div></div><divclass=\"ms-rtestate-readms-rte-wpbox\"><divclass=\"ms-rtestate-read\"id=\"div_\"></div><divclass=\"ms-rtestate-read\"id=\"vid_\"style=\"display&#58;none;\"></div></div></div></div></td></tr></tbody></table><spanid=\"layoutsData\"style=\"display&#58;none;\">false,false,1</span></div>";
+
+        // Home page with SiteFeedWebPart, XsltListViewWebPart and GettingStartedWebPart (normalized form).
+        // Verbatim from the legacy PageAnalyzer.DefaultHtml.
+        private const string DefaultHtml = "<divclass=\"<tableid=\"layoutsTable\"style=\"width&#58;100%;\"><tbody><trstyle=\"vertical-align&#58;top;\"><tdcolspan=\"2\"><divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\"><divclass=\"ms-rte-layoutszone-inner\"style=\"word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\"><divclass=\"ms-rtestate-readms-rte-wpbox\"><divclass=\"ms-rtestate-read\"id=\"div_\"></div><divclass=\"ms-rtestate-read\"id=\"vid_\"style=\"display&#58;none;\"></div></div></div></div></td></tr><trstyle=\"vertical-align&#58;top;\"><tdstyle=\"width&#58;49.95%;\"><divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\"><divclass=\"ms-rte-layoutszone-inner\"style=\"word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\"><divclass=\"ms-rtestate-readms-rte-wpbox\"><divclass=\"ms-rtestate-read\"id=\"div_\"></div><divclass=\"ms-rtestate-read\"id=\"vid_\"style=\"display&#58;none;\"></div></div></div></div></td><tdclass=\"ms-wiki-columnSpacing\"style=\"width&#58;49.95%;\"><divclass=\"ms-rte-layoutszone-outer\"style=\"width&#58;100%;\"><divclass=\"ms-rte-layoutszone-inner\"style=\"word-wrap&#58;break-word;margin&#58;0px;border&#58;0px;\"><divclass=\"ms-rtestate-readms-rte-wpbox\"><divclass=\"ms-rtestate-read\"id=\"div_\"></div><divclass=\"ms-rtestate-read\"id=\"vid_\"style=\"display&#58;none;\"></div></div></div></div></td></tr></tbody></table><spanid=\"layoutsData\"style=\"display&#58;none;\">true,false,2</span></div>";
+
+        private static readonly Regex GuidRegex = new("([0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})", RegexOptions.Compiled);
+        private static readonly Regex ExternalClassRegex = new(@"(ExternalClass.{32}"">)", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns the welcome page name to compare against, defaulting to <c>default.aspx</c> when the
+        /// web reports no welcome page (the legacy behaviour for web-part-page home pages).
+        /// </summary>
+        internal static string NormalizeWelcomePage(string welcomePage)
+        {
+            return string.IsNullOrEmpty(welcomePage) ? DefaultWelcomePage : welcomePage;
+        }
+
+        /// <summary>
+        /// Whether the given page is the web's home page: a case-insensitive suffix match of the page's
+        /// server-relative url against the web's welcome page. Ported from the legacy
+        /// <c>pageUrl.EndsWith(homePageUrl)</c> compare.
+        /// </summary>
+        /// <param name="pageUrl">The page's server-relative url.</param>
+        /// <param name="welcomePageUrl">The web's welcome page (<c>web.WelcomePage</c>); empty ⇒ default.aspx.</param>
+        internal static bool IsHomePage(string pageUrl, string welcomePageUrl)
+        {
+            if (string.IsNullOrEmpty(pageUrl))
+            {
+                return false;
+            }
+
+            return pageUrl.EndsWith(NormalizeWelcomePage(welcomePageUrl), StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines whether a wiki page's <c>WikiField</c> HTML still matches the out-of-the-box default
+        /// (i.e. the page was not customized). Ported verbatim from the legacy
+        /// <c>PageAnalyzer.IsHtmlUncustomized</c>: strip whitespace, GUIDs and the per-page
+        /// <c>ExternalClass</c> marker, then compare to the two captured default layouts.
+        /// </summary>
+        internal static bool IsHtmlUncustomized(string wikiHtml)
+        {
+            if (string.IsNullOrEmpty(wikiHtml))
+            {
+                return false;
+            }
+
+            string trimmed = wikiHtml.Replace("\r", "").Replace("\n", "").Replace("\r\n", "").Replace(" ", "").Trim();
+            trimmed = GuidRegex.Replace(trimmed, "");
+            trimmed = ExternalClassRegex.Replace(trimmed, "");
+
+            return trimmed == DefaultHtml || trimmed == DefaultRootHtml;
+        }
+
+        /// <summary>
+        /// Whether a team-site home page still has exactly the out-of-the-box default web part set: a single
+        /// XsltListView, no other list views, at most one each of the site-feed / getting-started parts, and
+        /// nothing else. Derived from the legacy <c>PageAnalyzer.GetPageWebPartInfo</c>, which produced four
+        /// categories but whose only consumer (this heuristic) cared solely about the "default set" one — so
+        /// it is reduced here to that single boolean rather than carrying three unused categories.
+        /// </summary>
+        internal static bool IsDefaultTeamSiteWebPartSet(IReadOnlyList<WebPartEntity> webParts)
+        {
+            int gettingStarted = 0;
+            int siteFeed = 0;
+            int xsltListView = 0;
+            int listView = 0;
+            int other = 0;
+
+            if (webParts != null)
+            {
+                foreach (var webPart in webParts)
+                {
+                    string name = webPart.TypeShort();
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        continue;
+                    }
+
+                    switch (name)
+                    {
+                        case GettingStartedWebPart:
+                            gettingStarted++;
+                            break;
+                        case SiteFeedWebPart:
+                            siteFeed++;
+                            break;
+                        case XsltListViewWebPart:
+                            xsltListView++;
+                            break;
+                        case ListViewWebPart:
+                            listView++;
+                            break;
+                        default:
+                            other++;
+                            break;
+                    }
+                }
+            }
+
+            return other == 0 && siteFeed <= 1 && gettingStarted <= 1 && xsltListView == 1 && listView == 0;
+        }
+
+        /// <summary>
+        /// The legacy fallback used to decide whether a home page is uncustomized when the CSOM
+        /// <c>web.CanModernizeHomepage</c> API is unavailable. Ported as a pure function from the
+        /// fallback branch of <c>PageAnalyzer.Analyze</c>: only a still-default <c>STS#0</c> team site home
+        /// page (no publishing, not groupified, not opted out, still on seattle.master, still named the
+        /// localized default home page, still the default wiki HTML, still the default web part set, still
+        /// the WikiEditForm content type) is considered uncustomized.
+        /// </summary>
+        /// <param name="isHomePage">Whether this page is the web's home page (see <see cref="IsHomePage"/>).</param>
+        /// <param name="webTemplate">The web template (e.g. <c>STS</c>).</param>
+        /// <param name="webConfiguration">The web template configuration (0 for a team site).</param>
+        /// <param name="publishingSiteFeatureEnabled">Whether the site publishing feature is enabled.</param>
+        /// <param name="publishingWebFeatureEnabled">Whether the web publishing feature is enabled.</param>
+        /// <param name="homePageModernizationOptedOut">Whether the home-page modernization opt-out web feature (<c>F478D140-…</c>) is present.</param>
+        /// <param name="siteWasGroupified">Whether the group-connected ("groupified") web feature (<c>E3DC7334-…</c>) is present.</param>
+        /// <param name="masterUrl">The web's master page url.</param>
+        /// <param name="pageName">The page's leaf name (FileLeafRef).</param>
+        /// <param name="localizedHomePageName">The localized default home page name (e.g. <c>Home.aspx</c>).</param>
+        /// <param name="wikiHtml">The page's <c>WikiField</c> HTML.</param>
+        /// <param name="webParts">The page's extracted web part inventory.</param>
+        /// <param name="contentTypeDisplayFormTemplateName">The page content type's display form template name.</param>
+        internal static bool IsUncustomizedHomePageFallback(
+            bool isHomePage,
+            string webTemplate,
+            int webConfiguration,
+            bool publishingSiteFeatureEnabled,
+            bool publishingWebFeatureEnabled,
+            bool homePageModernizationOptedOut,
+            bool siteWasGroupified,
+            string masterUrl,
+            string pageName,
+            string localizedHomePageName,
+            string wikiHtml,
+            IReadOnlyList<WebPartEntity> webParts,
+            string contentTypeDisplayFormTemplateName)
+        {
+            // Only a default STS#0 team site home page is a candidate.
+            if (!isHomePage || webTemplate != "STS" || webConfiguration != 0)
+            {
+                return false;
+            }
+
+            // Publishing or an explicit opt-out means the home page is not a default modern-ready one.
+            if (homePageModernizationOptedOut || publishingSiteFeatureEnabled || publishingWebFeatureEnabled)
+            {
+                return false;
+            }
+
+            // A group-connected site does not have the classic default home page.
+            if (siteWasGroupified)
+            {
+                return false;
+            }
+
+            // Still pointing at the default master page.
+            if (string.IsNullOrEmpty(masterUrl) || !masterUrl.EndsWith(SeattleMasterSuffix, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return false;
+            }
+
+            // Only the default home page name (Home.aspx or its localized equivalent) counts.
+            if (string.IsNullOrEmpty(pageName) || !pageName.Equals(localizedHomePageName, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return false;
+            }
+
+            // The wiki HTML must still be the out-of-the-box default.
+            if (!IsHtmlUncustomized(wikiHtml))
+            {
+                return false;
+            }
+
+            // The web part set must still be the default team site set.
+            if (!IsDefaultTeamSiteWebPartSet(webParts))
+            {
+                return false;
+            }
+
+            // And the content type must still be the default wiki edit form.
+            return string.Equals(contentTypeDisplayFormTemplateName, WikiEditForm, StringComparison.InvariantCulture);
+        }
+    }
+}


### PR DESCRIPTION
## What

Ports the Modernization Scanner's **home page** and **uncustomized home page**
semantics into the M365 Assessment tool's Classic page scan, as a pure,
unit-tested module. Part of the classic-page-scan parity effort (T10; follows
T5/T5a/T5b/T6/T7).

New file `Scanners/Classic/Pages/HomePageDetector.cs` (pure, no CSOM):

- **`IsHomePage(pageUrl, welcomePageUrl)`** + `NormalizeWelcomePage` — the legacy
  case-insensitive `pageUrl.EndsWith(web.WelcomePage)` compare, with the empty
  welcome page → `default.aspx` default (legacy behaviour for web-part-page homes).
- **`IsHtmlUncustomized(wikiHtml)`** — ported verbatim from
  `PageAnalyzer.IsHtmlUncustomized` (strip whitespace + GUIDs + the per-page
  `ExternalClass` marker, then compare to the two captured default layouts,
  copied verbatim).
- **`IsDefaultTeamSiteWebPartSet(webParts)`** — the default-web-part-set check
  derived from `PageAnalyzer.GetPageWebPartInfo`.
- **`IsUncustomizedHomePageFallback(...)`** — the entire legacy fallback branch
  ported as one pure function (STS#0 + not publishing + not opted-out + not
  groupified + still on seattle.master + still the localized default home-page
  name + still the default wiki HTML + still the default web part set + still the
  `WikiEditForm` content type). Takes resolved bools so the module stays pure.

The `ClassicPage.HomePage` / `UncustomizedHomePage` columns already exist (T1),
so no migration.

## Why split the CSOM out

The reliable `web.CanModernizeHomepage` primary path is a bare CSOM property read
(verified present in `Microsoft.SharePointOnline.CSOM 16.1.24614.12000`, returns
`ModernizeHomepageResult`) with no portable logic. Its fallback's CSOM glue
(features → bools, master url, content type, the localized home-page name) is tied
to per-web loop state. So — unlike the T5/T5b/T7 extract methods, which had a clean
self-contained signature — this PR ships the complete *decision logic* purely and
leaves the thin per-web CSOM input-gathering + the `CanModernizeHomepage` call (and
the `HomePageOnly` discovery filter) to the persistence wiring task (T8), exercised
end-to-end by the integration test (T15). Not wired into
`PageScanComponent.ExecuteAsync` — same deferral as T5/T5a/T5b/T6/T7.

## Tests

New `HomePageDetectorTests.cs` (25 tests): `IsHomePage` (equal / different / case /
empty-welcome-default / null), `IsHtmlUncustomized` (default-STS-true,
default-root-STS-true, customized-false, null/empty), `IsDefaultTeamSiteWebPartSet`
(default-set-true + four false controls), and `IsUncustomizedHomePageFallback` (the
all-conditions-true default STS home + one control per gating condition). The
default-home HTML fixtures are generated from the verbatim constants by re-inserting
stripped whitespace + per-web-part GUIDs (verified to renormalize).

Full Core.Tests suite green: **109/109**.

## Notes / hand-off

- **T8 must wire**: load `web.WelcomePage` per web → set `HomePage`; apply the
  `HomePageOnly` skip in the discovery loop; try `web.CanModernizeHomepage`, falling
  back to `IsUncustomizedHomePageFallback`. The two feature GUIDs the fallback needs
  (`F478D140-…` opt-out, `E3DC7334-…` groupified) go in `PageScanComponent` next to
  the existing publishing GUIDs, resolved via the existing `FeatureEnabled` helper.
- Reduced two ported-but-unconsumed pieces to what the logic actually uses: dropped
  the home-page feature GUID consts from the pure module, and collapsed the legacy
  4-value web-part-config enum to a single bool (only one value ever drove a decision).