### PR TITLE
Classic page scan (T8): persist web part inventory + wire enrichment end-to-end

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/StoragePageWebPartTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/StoragePageWebPartTests.cs
@@ -1,0 +1,154 @@
+﻿using FluentAssertions;
+using PnP.Scanning.Core.Storage;
+using PnP.Scanning.Core.Tests.Fixtures;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Storage
+{
+    /// <summary>
+    /// T8 — verifies the page-scan persistence: the new <see cref="StorageManager.StorePageWebPartsAsync"/>
+    /// bulk insert and that <see cref="StorageManager.StorePageInformationAsync"/> round-trips the
+    /// page-scan enrichment columns. Exercises the testable static cores against the shared in-memory
+    /// SQLite <see cref="ScanContext"/> fixture (the scanId overloads open the real on-disk scan DB).
+    /// </summary>
+    public class StoragePageWebPartTests : IClassFixture<ScanContextFixture>
+    {
+        private readonly ScanContextFixture fixture;
+
+        public StoragePageWebPartTests(ScanContextFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task StorePageWebParts_BulkInsert_RowsPersisted()
+        {
+            var scanId = Guid.NewGuid();
+            var siteUrl = $"https://contoso.sharepoint.com/sites/{scanId:N}";
+            var pageUrl = "/SitePages/Home.aspx";
+
+            var webParts = new List<ClassicPageWebPart>
+            {
+                NewWebPart(scanId, siteUrl, pageUrl, index: 0, type: "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart", isMappable: true),
+                NewWebPart(scanId, siteUrl, pageUrl, index: 1, type: "Microsoft.SharePoint.WebPartPages.XsltListViewWebPart", isMappable: true),
+                NewWebPart(scanId, siteUrl, pageUrl, index: 2, type: "Contoso.Custom.WebPart", isMappable: false),
+            };
+
+            using (var context = fixture.CreateContext())
+            {
+                await StorageManager.StorePageWebPartsAsync(context, webParts);
+            }
+
+            using (var context = fixture.CreateContext())
+            {
+                var stored = context.ClassicPageWebParts
+                    .Where(wp => wp.ScanId == scanId && wp.PageUrl == pageUrl)
+                    .OrderBy(wp => wp.WebPartIndex)
+                    .ToList();
+
+                stored.Should().HaveCount(3);
+
+                stored[0].WebPartType.Should().Be("Microsoft.SharePoint.WebPartPages.ContentEditorWebPart");
+                stored[0].WebPartTypeShort.Should().Be("ContentEditorWebPart");
+                stored[0].ZoneId.Should().Be("Header");
+                stored[0].Row.Should().Be(1);
+                stored[0].Column.Should().Be(2);
+                stored[0].Order.Should().Be(0);
+                stored[0].IsMappable.Should().BeTrue();
+
+                stored[2].WebPartType.Should().Be("Contoso.Custom.WebPart");
+                stored[2].IsMappable.Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task StorePageWebParts_EmptyList_NoOp()
+        {
+            var scanId = Guid.NewGuid();
+            var siteUrl = $"https://contoso.sharepoint.com/sites/{scanId:N}";
+
+            // Neither an empty list nor a null list should throw or write any rows.
+            using (var context = fixture.CreateContext())
+            {
+                await StorageManager.StorePageWebPartsAsync(context, new List<ClassicPageWebPart>());
+                await StorageManager.StorePageWebPartsAsync(context, null);
+            }
+
+            using (var context = fixture.CreateContext())
+            {
+                context.ClassicPageWebParts.Count(wp => wp.ScanId == scanId).Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public async Task StorePageInformation_EnrichedColumns_Persisted()
+        {
+            var scanId = Guid.NewGuid();
+            var siteUrl = $"https://contoso.sharepoint.com/sites/{scanId:N}";
+            var pageUrl = "/SitePages/Home.aspx";
+
+            var pages = new List<ClassicPage>
+            {
+                new()
+                {
+                    ScanId = scanId,
+                    SiteUrl = siteUrl,
+                    WebUrl = siteUrl,
+                    PageUrl = pageUrl,
+                    PageName = "Home.aspx",
+                    PageType = "WikiPage",
+                    RemediationCode = "CP2",
+                    // Page-scan enrichment columns (the fields T5-T7/T10 stamp before persistence).
+                    Layout = "TwoColumns",
+                    HomePage = true,
+                    UncustomizedHomePage = true,
+                    ModifiedBy = "jane@contoso.com",
+                    WebPartCount = 4,
+                    MappingPercentage = 75,
+                    UnmappedWebParts = "ContosoCustomWebPart",
+                },
+            };
+
+            using (var context = fixture.CreateContext())
+            {
+                await StorageManager.StorePageInformationAsync(context, pages);
+            }
+
+            using (var context = fixture.CreateContext())
+            {
+                var page = context.ClassicPages.Single(p => p.ScanId == scanId && p.PageUrl == pageUrl);
+
+                page.Layout.Should().Be("TwoColumns");
+                page.HomePage.Should().BeTrue();
+                page.UncustomizedHomePage.Should().BeTrue();
+                page.ModifiedBy.Should().Be("jane@contoso.com");
+                page.WebPartCount.Should().Be(4);
+                page.MappingPercentage.Should().Be(75);
+                page.UnmappedWebParts.Should().Be("ContosoCustomWebPart");
+                page.RemediationCode.Should().Be("CP2");
+            }
+        }
+
+        private static ClassicPageWebPart NewWebPart(Guid scanId, string siteUrl, string pageUrl, int index, string type, bool isMappable)
+        {
+            return new ClassicPageWebPart
+            {
+                ScanId = scanId,
+                SiteUrl = siteUrl,
+                WebUrl = siteUrl,
+                PageUrl = pageUrl,
+                WebPartIndex = index,
+                WebPartType = type,
+                WebPartTypeShort = type.Split(',')[0].Split('.').Last(),
+                WebPartTitle = $"Web part {index}",
+                ZoneId = "Header",
+                Row = 1,
+                Column = 2,
+                Order = index,
+                Hidden = false,
+                IsClosed = false,
+                IsMappable = isMappable,
+            };
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.SharePoint.Client;
+﻿using System.Text.RegularExpressions;
+using Microsoft.SharePoint.Client;
 using PnP.Core.Model.SharePoint;
 using PnP.Core.QueryModel;
 using PnP.Core.Services;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
 using PnP.Scanning.Core.Storage;
 
 namespace PnP.Scanning.Core.Scanners
@@ -11,6 +13,17 @@ namespace PnP.Scanning.Core.Scanners
         private static readonly Guid FeatureId_Site_Publishing = new("F6924D36-2FA8-4F0B-B16D-06B7250180FA");
         private static readonly Guid FeatureId_Web_Publishing = new("94C94CA6-B32F-4DA9-A9E3-1F3D343D7ECB");
         private static readonly Guid FeatureId_Web_ModernPage = new("B6917CB1-93A0-4B97-A84D-7CF49975D4EC");
+
+        // Home-page modernization opt-out web feature and the group-connected ("groupified") web feature.
+        // Resolved here (not in the pure HomePageDetector) because they are part of the per-web CSOM wiring.
+        // Ported from the legacy PageAnalyzer.
+        private static readonly Guid FeatureId_Web_HomePageModernizationOptOut = new("F478D140-B148-4038-9CB0-84A8F1E4BE09");
+        private static readonly Guid FeatureId_Web_GroupHomePage = new("E3DC7334-CEC0-4D2C-8B90-E4857698FC4E");
+
+        // The web part mapping model (embedded webpartmapping.xml) is read-only after construction, so a
+        // single shared instance is reused across webs/threads instead of re-parsing the ~1370-line file
+        // for every web.
+        private static readonly WebPartMappingManager MappingManager = new();
 
         // Fields
         private const string FileRefField = "FileRef";
@@ -38,20 +51,35 @@ namespace PnP.Scanning.Core.Scanners
         // File type value identifying a Delve blog page (point publishing)
         private const string DelveBlogFileType = "pointpub";
 
+        // The localized default home page resource (e.g. "Home") used to recognize an uncustomized STS#0 home page.
+        private const string WikiHomePageResource = "$Resources:WikiPageHomePageName";
+
         internal static async Task ExecuteAsync(ScannerBase scannerBase, PnPContext context, ClientContext csomContext)
         {
-            
+            var options = ((ClassicScanner)scannerBase).Options;
+
             List<ClassicPage> pagesList = new();
-            int modernPageCounter = 0;
+            List<PageEnrichmentInput> enrichmentInputs = new();
             HashSet<string> remediationCodes = new();
-
-            // Page ModifiedBy is a user lookup; skip it when user information is not wanted.
-            bool skipUserInformation = ((ClassicScanner)scannerBase).Options.SkipUserInformation;
-
-            var lists = ScannerBase.CleanLoadedLists(context);
 
             bool sitePublishingEnabled = FeatureEnabled(context.Site.Features, FeatureId_Site_Publishing);
             bool webPublishingEnabled = FeatureEnabled(context.Web.Features, FeatureId_Web_Publishing);
+
+            // The web's welcome page drives the HomePage flag and the optional HomePageOnly filter.
+            string welcomePage = await GetWelcomePageAsync(csomContext).ConfigureAwait(false);
+
+            var discovery = new PageDiscovery
+            {
+                ScannerBase = scannerBase,
+                WelcomePage = welcomePage,
+                HomePageOnly = options.HomePageOnly,
+                SkipUserInformation = options.SkipUserInformation,
+                Pages = pagesList,
+                RemediationCodes = remediationCodes,
+                EnrichmentInputs = enrichmentInputs,
+            };
+
+            var lists = ScannerBase.CleanLoadedLists(context);
 
             if (scannerBase.WebTemplate == "BLOG#0")
             {
@@ -64,39 +92,23 @@ namespace PnP.Scanning.Core.Scanners
                     {
                         foreach (var listItem in listItems)
                         {
-                            pagesList.Add(new ClassicPage
-                            {
-                                ScanId = scannerBase.ScanId,
-                                SiteUrl = scannerBase.SiteUrl,
-                                WebUrl = scannerBase.WebUrl,
-                                PageUrl = GetFieldValue(listItem, FileRefField, $"{listItem.Id}"),
-                                PageName = GetFieldValue(listItem, TitleField, ""),
-                                ListUrl = blogList.RootFolder.ServerRelativeUrl,
-                                ListTitle = blogList.Title,
-                                ListId = blogList.Id,
-                                ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
-                                ModifiedBy = GetModifiedBy(listItem.Values, skipUserInformation),
-                                PageType = BlogPage,
-                                RemediationCode = RemediationCodes.CP4.ToString(),
-                            });
-
-                            remediationCodes.Add(RemediationCodes.CP4.ToString());
+                            AddBlogPage(discovery, blogList, listItem);
                         }
                     }).ConfigureAwait(false);
                 }
             }
-            else if ((scannerBase.WebTemplate == "BLANKINTERNET#0" || scannerBase.WebTemplate == "ENTERWIKI#0" || 
+            else if ((scannerBase.WebTemplate == "BLANKINTERNET#0" || scannerBase.WebTemplate == "ENTERWIKI#0" ||
                       scannerBase.WebTemplate == "SRCHCEN#0" || scannerBase.WebTemplate == "CMSPUBLISHING#0") &&
                      sitePublishingEnabled && webPublishingEnabled)
             {
-                await QueryPublishingPagesAsync(scannerBase, pagesList, lists, remediationCodes, skipUserInformation).ConfigureAwait(false);
+                await QueryPublishingPagesAsync(discovery, lists).ConfigureAwait(false);
             }
             else
             {
                 // A team site can also have the publishing features enabled
                 if (sitePublishingEnabled && webPublishingEnabled)
                 {
-                    await QueryPublishingPagesAsync(scannerBase, pagesList, lists, remediationCodes, skipUserInformation).ConfigureAwait(false);
+                    await QueryPublishingPagesAsync(discovery, lists).ConfigureAwait(false);
                 }
 
                 // Check for the regular pages library
@@ -110,54 +122,50 @@ namespace PnP.Scanning.Core.Scanners
                         {
                             foreach (var listItem in listItems)
                             {
-                                var pageToAdd = new ClassicPage
-                                {
-                                    ScanId = scannerBase.ScanId,
-                                    SiteUrl = scannerBase.SiteUrl,
-                                    WebUrl = scannerBase.WebUrl,
-                                    PageUrl = GetFieldValue(listItem, FileRefField, $"{listItem.Id}"),
-                                    PageName = GetFieldValue(listItem, TitleField, "") != "" ? GetFieldValue(listItem, TitleField, "") : Path.GetFileNameWithoutExtension(GetFieldValue(listItem, FileRefField, $"{listItem.Id}")),
-                                    ListUrl = sitePagesLibrary.RootFolder.ServerRelativeUrl,
-                                    ListTitle = sitePagesLibrary.Title,
-                                    ListId = sitePagesLibrary.Id,
-                                    ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
-                                    ModifiedBy = GetModifiedBy(listItem.Values, skipUserInformation),
-                                    PageType = GetPageType(listItem)
-                                };
-
-                                switch (pageToAdd.PageType)
-                                {
-                                    case WikiPage:
-                                        pageToAdd.RemediationCode = RemediationCodes.CP2.ToString();
-                                        remediationCodes.Add(RemediationCodes.CP2.ToString());
-                                        break;
-                                    case WebPartPage:
-                                        pageToAdd.RemediationCode = RemediationCodes.CP1.ToString();
-                                        remediationCodes.Add(RemediationCodes.CP1.ToString());
-                                        break;
-                                    case ASPXPage:
-                                        pageToAdd.RemediationCode = RemediationCodes.CP5.ToString();
-                                        remediationCodes.Add(RemediationCodes.CP5.ToString());
-                                        break;
-                                }
-
-                                if (pageToAdd.AddToDatabase())
-                                {
-                                    pagesList.Add(pageToAdd);
-                                }
-                                else
-                                {
-                                    modernPageCounter++;
-                                }
+                                AddSitePage(discovery, sitePagesLibrary, listItem);
                             }
                         }).ConfigureAwait(false);
                     }
                 }
             }
 
+            // Enrich the discovered classic pages with their web part inventory, mapping readiness, page
+            // layout and (for the home page) the uncustomized-home-page verdict. Only web part / wiki /
+            // publishing pages carry a transformable web part surface, so only those were captured for
+            // enrichment. Per-page failures are logged and skipped — a single bad page must not fail the web.
+            List<ClassicPageWebPart> webPartsList = new();
+            foreach (var input in enrichmentInputs)
+            {
+                try
+                {
+                    var pageWebParts = await ExtractWebPartsAsync(csomContext, input, options.ExportWebPartProperties).ConfigureAwait(false);
+
+                    // Stamps IsMappable per web part + WebPartCount / MappingPercentage / UnmappedWebParts on the page.
+                    PageMappingCalculator.ApplyMapping(input.Page, pageWebParts, MappingManager);
+
+                    webPartsList.AddRange(pageWebParts);
+
+                    if (input.Page.HomePage)
+                    {
+                        input.Page.UncustomizedHomePage = await DetermineUncustomizedHomePageAsync(
+                            scannerBase, context, csomContext, input, pageWebParts,
+                            sitePublishingEnabled, webPublishingEnabled).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    scannerBase.Logger.Warning(ex, "Failed to assess the web parts of classic page {PageUrl}; skipping its inventory", input.Page.PageUrl);
+                }
+            }
+
             if (pagesList.Count > 0)
             {
                 await scannerBase.StorageManager.StorePageInformationAsync(scannerBase.ScanId, pagesList);
+            }
+
+            if (webPartsList.Count > 0)
+            {
+                await scannerBase.StorageManager.StorePageWebPartsAsync(scannerBase.ScanId, webPartsList);
             }
 
             // Loop over the found pages and save the page summary information
@@ -190,10 +198,101 @@ namespace PnP.Scanning.Core.Scanners
             }
 
             await scannerBase.StorageManager.StorePageSummaryAsync(scannerBase.ScanId, scannerBase.SiteUrl, scannerBase.WebUrl, scannerBase.WebTemplate, context, remediationCodes,
-                                                                   modernPageCounter, wikiPageCounter, blogPageCounter, webPartPageCounter, aspxPageCounter, publishingPageCounter);
+                                                                   discovery.ModernPageCounter, wikiPageCounter, blogPageCounter, webPartPageCounter, aspxPageCounter, publishingPageCounter);
         }
 
-        private static async Task QueryPublishingPagesAsync(ScannerBase scannerBase, List<ClassicPage> pagesList, List<IList> lists, HashSet<string> remediationCodes, bool skipUserInformation)
+        private static void AddBlogPage(PageDiscovery disc, IList blogList, IListItem listItem)
+        {
+            string pageUrl = GetFieldValue(listItem, FileRefField, $"{listItem.Id}");
+
+            if (disc.HomePageOnly && !HomePageDetector.IsHomePage(pageUrl, disc.WelcomePage))
+            {
+                return;
+            }
+
+            disc.Pages.Add(new ClassicPage
+            {
+                ScanId = disc.ScannerBase.ScanId,
+                SiteUrl = disc.ScannerBase.SiteUrl,
+                WebUrl = disc.ScannerBase.WebUrl,
+                PageUrl = pageUrl,
+                PageName = GetFieldValue(listItem, TitleField, ""),
+                ListUrl = blogList.RootFolder.ServerRelativeUrl,
+                ListTitle = blogList.Title,
+                ListId = blogList.Id,
+                ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
+                ModifiedBy = GetModifiedBy(listItem.Values, disc.SkipUserInformation),
+                PageType = BlogPage,
+                HomePage = HomePageDetector.IsHomePage(pageUrl, disc.WelcomePage),
+                RemediationCode = RemediationCodes.CP4.ToString(),
+            });
+
+            disc.RemediationCodes.Add(RemediationCodes.CP4.ToString());
+        }
+
+        private static void AddSitePage(PageDiscovery disc, IList sitePagesLibrary, IListItem listItem)
+        {
+            string pageUrl = GetFieldValue(listItem, FileRefField, $"{listItem.Id}");
+
+            if (disc.HomePageOnly && !HomePageDetector.IsHomePage(pageUrl, disc.WelcomePage))
+            {
+                return;
+            }
+
+            var pageToAdd = new ClassicPage
+            {
+                ScanId = disc.ScannerBase.ScanId,
+                SiteUrl = disc.ScannerBase.SiteUrl,
+                WebUrl = disc.ScannerBase.WebUrl,
+                PageUrl = pageUrl,
+                PageName = GetFieldValue(listItem, TitleField, "") != "" ? GetFieldValue(listItem, TitleField, "") : Path.GetFileNameWithoutExtension(pageUrl),
+                ListUrl = sitePagesLibrary.RootFolder.ServerRelativeUrl,
+                ListTitle = sitePagesLibrary.Title,
+                ListId = sitePagesLibrary.Id,
+                ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
+                ModifiedBy = GetModifiedBy(listItem.Values, disc.SkipUserInformation),
+                PageType = GetPageType(listItem),
+                HomePage = HomePageDetector.IsHomePage(pageUrl, disc.WelcomePage),
+            };
+
+            switch (pageToAdd.PageType)
+            {
+                case WikiPage:
+                    pageToAdd.RemediationCode = RemediationCodes.CP2.ToString();
+                    disc.RemediationCodes.Add(RemediationCodes.CP2.ToString());
+                    break;
+                case WebPartPage:
+                    pageToAdd.RemediationCode = RemediationCodes.CP1.ToString();
+                    disc.RemediationCodes.Add(RemediationCodes.CP1.ToString());
+                    break;
+                case ASPXPage:
+                    pageToAdd.RemediationCode = RemediationCodes.CP5.ToString();
+                    disc.RemediationCodes.Add(RemediationCodes.CP5.ToString());
+                    break;
+            }
+
+            if (pageToAdd.AddToDatabase())
+            {
+                disc.Pages.Add(pageToAdd);
+
+                // Wiki and web part pages carry a web part inventory we can extract + map.
+                if (pageToAdd.PageType == WikiPage || pageToAdd.PageType == WebPartPage)
+                {
+                    disc.EnrichmentInputs.Add(new PageEnrichmentInput
+                    {
+                        Page = pageToAdd,
+                        WikiFieldHtml = GetFieldValue<string>(listItem, WikiField),
+                        FileLeafRef = GetFieldValue(listItem, FileLeafRefField, ""),
+                    });
+                }
+            }
+            else
+            {
+                disc.ModernPageCounter++;
+            }
+        }
+
+        private static async Task QueryPublishingPagesAsync(PageDiscovery disc, List<IList> lists)
         {
             var pagesLibrary = lists.FirstOrDefault(l => l.TemplateType == PnP.Core.Model.SharePoint.ListTemplateType.PublishingPagesLibrary);
             if (pagesLibrary != null)
@@ -203,26 +302,173 @@ namespace PnP.Scanning.Core.Scanners
                 {
                     foreach (var listItem in listItems)
                     {
-                        pagesList.Add(new ClassicPage
-                        {
-                            ScanId = scannerBase.ScanId,
-                            SiteUrl = scannerBase.SiteUrl,
-                            WebUrl = scannerBase.WebUrl,
-                            PageUrl = GetFieldValue(listItem, FileRefField, $"{listItem.Id}"),
-                            PageName = GetFieldValue(listItem, TitleField, "") != "" ? GetFieldValue(listItem, TitleField, "") : Path.GetFileNameWithoutExtension(GetFieldValue(listItem, FileRefField, $"{listItem.Id}")),
-                            ListUrl = pagesLibrary.RootFolder.ServerRelativeUrl,
-                            ListTitle = pagesLibrary.Title,
-                            ListId = pagesLibrary.Id,
-                            ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
-                            ModifiedBy = GetModifiedBy(listItem.Values, skipUserInformation),
-                            PageType = PublishingPage,
-                            RemediationCode = RemediationCodes.CP3.ToString(),
-                        });
-
-                        remediationCodes.Add(RemediationCodes.CP4.ToString());
+                        AddPublishingPage(disc, pagesLibrary, listItem);
                     }
                 }).ConfigureAwait(false);
             }
+        }
+
+        private static void AddPublishingPage(PageDiscovery disc, IList pagesLibrary, IListItem listItem)
+        {
+            string pageUrl = GetFieldValue(listItem, FileRefField, $"{listItem.Id}");
+
+            if (disc.HomePageOnly && !HomePageDetector.IsHomePage(pageUrl, disc.WelcomePage))
+            {
+                return;
+            }
+
+            var pageToAdd = new ClassicPage
+            {
+                ScanId = disc.ScannerBase.ScanId,
+                SiteUrl = disc.ScannerBase.SiteUrl,
+                WebUrl = disc.ScannerBase.WebUrl,
+                PageUrl = pageUrl,
+                PageName = GetFieldValue(listItem, TitleField, "") != "" ? GetFieldValue(listItem, TitleField, "") : Path.GetFileNameWithoutExtension(pageUrl),
+                ListUrl = pagesLibrary.RootFolder.ServerRelativeUrl,
+                ListTitle = pagesLibrary.Title,
+                ListId = pagesLibrary.Id,
+                ModifiedAt = GetFieldValue<DateTime>(listItem, ModifiedField),
+                ModifiedBy = GetModifiedBy(listItem.Values, disc.SkipUserInformation),
+                PageType = PublishingPage,
+                HomePage = HomePageDetector.IsHomePage(pageUrl, disc.WelcomePage),
+                RemediationCode = RemediationCodes.CP3.ToString(),
+            };
+
+            disc.Pages.Add(pageToAdd);
+            // CP3 = Publishing page (matches pageToAdd.RemediationCode). Pre-T8 this added CP4 (Blog page),
+            // a copy-paste quirk that mislabeled a publishing web's aggregated remediation codes.
+            disc.RemediationCodes.Add(RemediationCodes.CP3.ToString());
+
+            disc.EnrichmentInputs.Add(new PageEnrichmentInput
+            {
+                Page = pageToAdd,
+                WikiFieldHtml = null,
+                FileLeafRef = GetFieldValue(listItem, FileLeafRefField, ""),
+            });
+        }
+
+        // Dispatches a discovered page to the right web part extractor. Web part / wiki / publishing
+        // pages each have a dedicated CSOM extraction path; anything else yields no web parts.
+        private static async Task<List<ClassicPageWebPart>> ExtractWebPartsAsync(ClientContext csomContext, PageEnrichmentInput input, bool exportWebPartProperties)
+        {
+            switch (input.Page.PageType)
+            {
+                case WebPartPage:
+                    return await PageWebPartExtractor.ExtractFromWebPartPageAsync(csomContext, input.Page, exportWebPartProperties).ConfigureAwait(false);
+                case WikiPage:
+                    return await PageWebPartExtractor.ExtractFromWikiPageAsync(csomContext, input.Page, input.WikiFieldHtml, exportWebPartProperties).ConfigureAwait(false);
+                case PublishingPage:
+                    return await PageWebPartExtractor.ExtractFromPublishingPageAsync(csomContext, input.Page, exportWebPartProperties).ConfigureAwait(false);
+                default:
+                    return new List<ClassicPageWebPart>();
+            }
+        }
+
+        // Determines whether the web's home page is a still-default ("uncustomized") home page. The
+        // reliable answer comes from the CanModernizeHomepage CSOM API (a bare property read with no logic
+        // to port); when that API is unavailable we fall back to the legacy HTML/web-part heuristic, whose
+        // pure decision lives in HomePageDetector. This per-web CSOM wiring is the T8 hand-off from T10.
+        private static async Task<bool> DetermineUncustomizedHomePageAsync(
+            ScannerBase scannerBase, PnPContext context, ClientContext csomContext,
+            PageEnrichmentInput input, List<ClassicPageWebPart> pageWebParts,
+            bool publishingSiteFeatureEnabled, bool publishingWebFeatureEnabled)
+        {
+            // Primary path: the CanModernizeHomepage CSOM API.
+            try
+            {
+                var canModernizeHomepage = csomContext.Web.CanModernizeHomepage;
+                csomContext.Load(canModernizeHomepage);
+                await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+                return canModernizeHomepage.CanModernizeHomepage;
+            }
+            catch (Exception ex)
+            {
+                scannerBase.Logger.Information(ex, "CanModernizeHomepage API unavailable for {PageUrl}; falling back to the HTML heuristic", input.Page.PageUrl);
+            }
+
+            // Fallback path: gather the inputs the legacy heuristic needs and let HomePageDetector decide.
+            try
+            {
+                var (template, configuration) = SplitWebTemplate(scannerBase.WebTemplate);
+
+                bool homePageModernizationOptedOut = FeatureEnabled(context.Web.Features, FeatureId_Web_HomePageModernizationOptOut);
+                bool siteWasGroupified = FeatureEnabled(context.Web.Features, FeatureId_Web_GroupHomePage);
+
+                var web = csomContext.Web;
+                csomContext.Load(web, w => w.MasterUrl, w => w.Language);
+                var listItem = web.GetFileByServerRelativeUrl(input.Page.PageUrl).ListItemAllFields;
+                csomContext.Load(listItem.ContentType, ct => ct.DisplayFormTemplateName);
+                await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+                string localizedHomePageName = await GetLocalizedHomePageNameAsync(csomContext, (int)web.Language).ConfigureAwait(false);
+
+                // HomePageDetector works over WebPartEntity; project the short type from the extracted rows.
+                var entities = pageWebParts.Select(wp => new WebPartEntity { Type = wp.WebPartType }).ToList();
+
+                return HomePageDetector.IsUncustomizedHomePageFallback(
+                    isHomePage: true,
+                    webTemplate: template,
+                    webConfiguration: configuration,
+                    publishingSiteFeatureEnabled: publishingSiteFeatureEnabled,
+                    publishingWebFeatureEnabled: publishingWebFeatureEnabled,
+                    homePageModernizationOptedOut: homePageModernizationOptedOut,
+                    siteWasGroupified: siteWasGroupified,
+                    masterUrl: web.MasterUrl,
+                    pageName: input.FileLeafRef,
+                    localizedHomePageName: localizedHomePageName,
+                    wikiHtml: input.WikiFieldHtml,
+                    webParts: entities,
+                    contentTypeDisplayFormTemplateName: listItem.ContentType.DisplayFormTemplateName);
+            }
+            catch (Exception ex)
+            {
+                scannerBase.Logger.Warning(ex, "Uncustomized home page fallback failed for {PageUrl}", input.Page.PageUrl);
+                return false;
+            }
+        }
+
+        // Resolves the localized default home page name (e.g. "Home.aspx"). Ported from the legacy
+        // PageAnalyzer: strip the quote-like characters the resource may carry and append ".aspx".
+        private static async Task<string> GetLocalizedHomePageNameAsync(ClientContext csomContext, int language)
+        {
+            var result = Microsoft.SharePoint.Client.Utilities.Utility.GetLocalizedString(csomContext, WikiHomePageResource, "core", language);
+            await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+            return $"{Regex.Replace(result.Value ?? "", @"['´`]", "")}.aspx";
+        }
+
+        // Reads the web's welcome page (server-relative-from-web), used for the HomePage flag and the
+        // HomePageOnly filter. Returns an empty string when the property cannot be read so discovery
+        // continues (HomePageDetector defaults the empty welcome page to default.aspx).
+        private static async Task<string> GetWelcomePageAsync(ClientContext csomContext)
+        {
+            try
+            {
+                var rootFolder = csomContext.Web.RootFolder;
+                csomContext.Load(rootFolder, f => f.WelcomePage);
+                await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+                return rootFolder.WelcomePage ?? "";
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+        // Splits a web template like "STS#0" into its template ("STS") and configuration (0). An
+        // unparseable configuration yields -1 so it never accidentally matches the default home page (0).
+        private static (string template, int configuration) SplitWebTemplate(string webTemplate)
+        {
+            if (string.IsNullOrEmpty(webTemplate))
+            {
+                return ("", -1);
+            }
+
+            var parts = webTemplate.Split('#');
+            int configuration = parts.Length > 1 && int.TryParse(parts[1], out var parsed) ? parsed : -1;
+            return (parts[0], configuration);
         }
 
         private static async Task QueryListAsync(IList list, string viewXml, Action<IEnumerable<IListItem>> processResults)
@@ -234,7 +480,7 @@ namespace PnP.Scanning.Core.Scanners
                 // Clear the previous page (if any)
                 list.Items.Clear();
 
-                // Execute the query, this populates a page of list items 
+                // Execute the query, this populates a page of list items
                 var output = await list.LoadListDataAsStreamAsync(new PnP.Core.Model.SharePoint.RenderListDataOptions()
                 {
                     ViewXml = viewXml,
@@ -294,7 +540,7 @@ namespace PnP.Scanning.Core.Scanners
                     <FieldRef Name='{TitleField}' />
                     <FieldRef Name='{BSNField}' />
                     {extraViewFields}
-                  </ViewFields> 
+                  </ViewFields>
                   {filter}
                   <OrderBy Override='TRUE'><FieldRef Name= 'ID' Ascending= 'FALSE' /></OrderBy>
                   <RowLimit Paged='TRUE'>1000</RowLimit>
@@ -375,6 +621,38 @@ namespace PnP.Scanning.Core.Scanners
             }
 
             return null;
+        }
+
+        // Cross-cutting state threaded through the per-web page discovery branches.
+        private sealed class PageDiscovery
+        {
+            public ScannerBase ScannerBase { get; init; }
+
+            public string WelcomePage { get; init; }
+
+            public bool HomePageOnly { get; init; }
+
+            public bool SkipUserInformation { get; init; }
+
+            public List<ClassicPage> Pages { get; init; }
+
+            public HashSet<string> RemediationCodes { get; init; }
+
+            public List<PageEnrichmentInput> EnrichmentInputs { get; init; }
+
+            // Modern pages are discovered but not persisted; they are only counted for the summary.
+            public int ModernPageCounter { get; set; }
+        }
+
+        // A discovered page plus the discovery-time field values the enrichment step needs (the wiki HTML
+        // and the page leaf name), captured because the live list items are released as discovery pages.
+        private sealed class PageEnrichmentInput
+        {
+            public ClassicPage Page { get; init; }
+
+            public string WikiFieldHtml { get; init; }
+
+            public string FileLeafRef { get; init; }
         }
     }
 }

--- a/src/PnP.Scanning/PnP.Scanning.Core/Storage/StorageManager.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Storage/StorageManager.cs
@@ -899,11 +899,44 @@ namespace PnP.Scanning.Core.Storage
         {
             using (var dbContext = new ScanContext(scanId))
             {
-                await dbContext.ClassicPages.AddRangeAsync(pagesLists.ToArray());
-
-                await dbContext.SaveChangesAsync();
-                Log.Information("StorePageInformationAsync succeeded");
+                await StorePageInformationAsync(dbContext, pagesLists);
             }
+        }
+
+        // Testable core (in-memory SQLite friendly): bulk insert the (enriched) page rows on the
+        // supplied context. Split out from the scanId overload so the persistence of the page-scan
+        // enrichment columns can be unit-tested against the shared in-memory ScanContext fixture.
+        internal static async Task StorePageInformationAsync(ScanContext dbContext, List<ClassicPage> pagesLists)
+        {
+            await dbContext.ClassicPages.AddRangeAsync(pagesLists.ToArray());
+
+            await dbContext.SaveChangesAsync();
+            Log.Information("StorePageInformationAsync succeeded");
+        }
+
+        internal async Task StorePageWebPartsAsync(Guid scanId, List<ClassicPageWebPart> pageWebPartsList)
+        {
+            using (var dbContext = new ScanContext(scanId))
+            {
+                await StorePageWebPartsAsync(dbContext, pageWebPartsList);
+            }
+        }
+
+        // Testable core (in-memory SQLite friendly): bulk insert the per-page web part inventory rows
+        // on the supplied context, following the StorePageInformationAsync pattern. A null/empty list
+        // is a no-op (no database round-trip), so a page with no web parts does not trigger an empty
+        // SaveChanges.
+        internal static async Task StorePageWebPartsAsync(ScanContext dbContext, List<ClassicPageWebPart> pageWebPartsList)
+        {
+            if (pageWebPartsList == null || pageWebPartsList.Count == 0)
+            {
+                return;
+            }
+
+            await dbContext.ClassicPageWebParts.AddRangeAsync(pageWebPartsList.ToArray());
+
+            await dbContext.SaveChangesAsync();
+            Log.Information("StorePageWebPartsAsync succeeded");
         }
 
         internal async Task StoreClassicListInformationAsync(Guid scanId, List<ClassicList> classicLists)
@@ -1426,6 +1459,11 @@ namespace PnP.Scanning.Core.Storage
             foreach (var page in await dbContext.ClassicPages.Where(p => p.ScanId == scanId && p.SiteUrl == site.SiteUrl && p.WebUrl == web.WebUrl).ToListAsync())
             {
                 dbContext.ClassicPages.Remove(page);
+            }
+
+            foreach (var pageWebPart in await dbContext.ClassicPageWebParts.Where(p => p.ScanId == scanId && p.SiteUrl == site.SiteUrl && p.WebUrl == web.WebUrl).ToListAsync())
+            {
+                dbContext.ClassicPageWebParts.Remove(pageWebPart);
             }
 
             foreach (var list in await dbContext.ClassicLists.Where(p => p.ScanId == scanId && p.SiteUrl == site.SiteUrl && p.WebUrl == web.WebUrl).ToListAsync())


### PR DESCRIPTION
## What

Lands the classic page **transformation-readiness** path end-to-end. Adds the web-part
persistence method and wires the previously-shipped-but-unwired extraction/mapping/home-page
modules (T5/T5a/T5b/T6/T7/T10) into `PageScanComponent`, so a Classic page scan now produces
per-page web part inventory, mapping %, page layout, home-page flags, and the uncustomized-home
verdict — not just page discovery.

## Why

T5–T7 and T10 shipped their logic as standalone, unit-tested modules that were intentionally
**not** called from the scan loop ("T8 owns the per-web call + bulk persist"). Until this PR the
enrichment never ran. This is the integration PR that connects them and stores the results.

## Changes

**`Storage/StorageManager.cs`**
- New `StorePageWebPartsAsync` (bulk insert `ClassicPageWebPart`, `AddRangeAsync` pattern matching
  `StorePageInformationAsync`; empty/null list = no-op).
- Both store methods split into a public `scanId` overload + an `internal static (ScanContext, …)`
  core so the inserts are unit-testable against the in-memory SQLite fixture.
- **Resume fix:** `DropClassicIncompleteWebScanDataAsync` now also drops `ClassicPageWebParts` for
  the dropped web (it dropped `ClassicPages` but not the new child table).

**`Scanners/Classic/PageScanComponent.cs`**
- Discovery refactored behind a `PageDiscovery` state bag + `Add{Blog,Site,Publishing}Page` helpers.
- Per-page enrichment loop: extractor dispatch (WebPart/Wiki/Publishing) → `PageMappingCalculator`
  → (home page only) uncustomized-home verdict → accumulate rows → persist pages + web parts.
  Each page is wrapped in try/catch (log + skip) so one bad page never fails the web.
- **HomePage / HomePageOnly:** welcome page loaded once via CSOM `RootFolder.WelcomePage`; `HomePage`
  flag set in every branch; HomePageOnly filter applied in discovery.
- **UncustomizedHomePage:** primary `web.CanModernizeHomepage` CSOM, with the full legacy
  HTML/feature/master-page fallback via `HomePageDetector` when that API throws.
- `WebPartMappingManager` made a `static readonly` singleton (parse `webpartmapping.xml` once).
- **Bug fix:** publishing pages now add `CP3` (Publishing) to the web's aggregated remediation set
  instead of `CP4` (Blog) — a pre-existing copy-paste quirk that would mislabel publishing-site
  summaries once T9/T11 consume the codes. Per-page `RemediationCode` was already correct.

**`Tests/Storage/StoragePageWebPartTests.cs`** (new)
- `StorePageWebParts_BulkInsert_RowsPersisted`, `StorePageWebParts_EmptyList_NoOp`,
  `StorePageInformation_EnrichedColumns_Persisted`.

## Decisions / notes

- **Only WebPart/Wiki/Publishing pages are enriched** (the three with an extractor path); blog/ASPX/
  Delve pages are left at column defaults, matching the legacy scanner.
- **Localized home-page name is not cached** (the legacy `ScannerBase.Cache` per-language cache):
  the cache helpers are `protected`/unreachable from the static component and the fallback only fires
  when `CanModernizeHomepage` throws (rare on SPO). Worst case = one extra lightweight CSOM call per
  web's home page in that degraded path; no correctness impact.
- All CSOM round-trips here (`LimitedWebPartManager` extraction, `CanModernizeHomepage` + fallback,
  `GetLocalizedString`) are **integration-only** and exercised by **T15**'s live-tenant test, not unit
  tests. `CanModernizeHomepage` confirmed present in the referenced CSOM package by reflection.

## Testing

`dotnet test` — **112 passed, 0 failed** (+3 new). New source files saved UTF-8 BOM + CRLF per repo
convention.