### PR TITLE
Classic page-scan CSV exports (page web parts + unique web part inventory)

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/ClassicReportExportTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/ClassicReportExportTests.cs
@@ -1,0 +1,290 @@
+﻿using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+using FluentAssertions;
+using PnP.Scanning.Core.Services;
+using PnP.Scanning.Core.Storage;
+using PnP.Scanning.Core.Tests.Fixtures;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Storage
+{
+    /// <summary>
+    /// T11 — verifies the Classic CSV report export: the new <c>classicpagewebparts.csv</c> /
+    /// <c>classicwebpartunique.csv</c> files and the enriched <c>classicpages.csv</c> columns are
+    /// emitted with the right header schema and row values. Seeds the shared in-memory SQLite
+    /// <see cref="ScanContext"/> fixture, runs the testable static export core
+    /// <see cref="ReportManager.ExportClassicReportDataAsync"/> into a temp directory, then re-reads
+    /// each CSV with CsvHelper.
+    /// </summary>
+    public class ClassicReportExportTests : IClassFixture<ScanContextFixture>
+    {
+        private readonly ScanContextFixture fixture;
+
+        public ClassicReportExportTests(ScanContextFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Csv_PageWebParts_HeaderAndRows()
+        {
+            var scanId = Guid.NewGuid();
+            var siteUrl = $"https://contoso.sharepoint.com/sites/{scanId:N}";
+            var pageUrl = "/SitePages/Home.aspx";
+
+            var webParts = new List<ClassicPageWebPart>
+            {
+                NewWebPart(scanId, siteUrl, pageUrl, index: 0, type: "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart",
+                           shortType: "ContentEditorWebPart", isMappable: true),
+                NewWebPart(scanId, siteUrl, pageUrl, index: 1, type: "Contoso.Custom.WebPart",
+                           shortType: "WebPart", isMappable: false),
+            };
+
+            using (var context = fixture.CreateContext())
+            {
+                await context.ClassicPageWebParts.AddRangeAsync(webParts);
+                await context.SaveChangesAsync();
+            }
+
+            var exportDir = NewTempDir();
+            try
+            {
+                await ExportAsync(scanId, exportDir);
+
+                var file = Path.Join(exportDir, "classicpagewebparts.csv");
+                File.Exists(file).Should().BeTrue();
+
+                ReadHeader(file).Should().Contain(new[]
+                {
+                    nameof(ClassicPageWebPart.ScanId),
+                    nameof(ClassicPageWebPart.SiteUrl),
+                    nameof(ClassicPageWebPart.WebUrl),
+                    nameof(ClassicPageWebPart.PageUrl),
+                    nameof(ClassicPageWebPart.WebPartIndex),
+                    nameof(ClassicPageWebPart.WebPartType),
+                    nameof(ClassicPageWebPart.WebPartTypeShort),
+                    nameof(ClassicPageWebPart.WebPartTitle),
+                    nameof(ClassicPageWebPart.ZoneId),
+                    nameof(ClassicPageWebPart.Row),
+                    nameof(ClassicPageWebPart.Column),
+                    nameof(ClassicPageWebPart.Order),
+                    nameof(ClassicPageWebPart.Hidden),
+                    nameof(ClassicPageWebPart.IsClosed),
+                    nameof(ClassicPageWebPart.IsMappable),
+                });
+
+                var rows = ReadRecords<ClassicPageWebPart>(file)
+                    .Where(wp => wp.ScanId == scanId)
+                    .OrderBy(wp => wp.WebPartIndex)
+                    .ToList();
+
+                rows.Should().HaveCount(2);
+
+                rows[0].WebPartType.Should().Be("Microsoft.SharePoint.WebPartPages.ContentEditorWebPart");
+                rows[0].WebPartTypeShort.Should().Be("ContentEditorWebPart");
+                rows[0].ZoneId.Should().Be("Header");
+                rows[0].Row.Should().Be(1);
+                rows[0].Column.Should().Be(2);
+                rows[0].IsMappable.Should().BeTrue();
+
+                rows[1].WebPartType.Should().Be("Contoso.Custom.WebPart");
+                rows[1].IsMappable.Should().BeFalse();
+            }
+            finally
+            {
+                DeleteTempDir(exportDir);
+            }
+        }
+
+        [Fact]
+        public async Task Csv_WebPartUnique_HeaderAndRows()
+        {
+            var scanId = Guid.NewGuid();
+
+            var uniques = new List<ClassicWebPartUnique>
+            {
+                new() { ScanId = scanId, WebPartType = "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart", InMappingFile = true, PageCount = 3 },
+                new() { ScanId = scanId, WebPartType = "Contoso.Custom.WebPart", InMappingFile = false, PageCount = 1 },
+            };
+
+            using (var context = fixture.CreateContext())
+            {
+                await context.ClassicWebPartUniques.AddRangeAsync(uniques);
+                await context.SaveChangesAsync();
+            }
+
+            var exportDir = NewTempDir();
+            try
+            {
+                await ExportAsync(scanId, exportDir);
+
+                var file = Path.Join(exportDir, "classicwebpartunique.csv");
+                File.Exists(file).Should().BeTrue();
+
+                ReadHeader(file).Should().Contain(new[]
+                {
+                    nameof(ClassicWebPartUnique.ScanId),
+                    nameof(ClassicWebPartUnique.WebPartType),
+                    nameof(ClassicWebPartUnique.InMappingFile),
+                    nameof(ClassicWebPartUnique.PageCount),
+                });
+
+                var rows = ReadRecords<ClassicWebPartUnique>(file)
+                    .Where(u => u.ScanId == scanId)
+                    .ToList();
+
+                rows.Should().HaveCount(2);
+
+                var contentEditor = rows.Single(u => u.WebPartType == "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart");
+                contentEditor.InMappingFile.Should().BeTrue();
+                contentEditor.PageCount.Should().Be(3);
+
+                var custom = rows.Single(u => u.WebPartType == "Contoso.Custom.WebPart");
+                custom.InMappingFile.Should().BeFalse();
+                custom.PageCount.Should().Be(1);
+            }
+            finally
+            {
+                DeleteTempDir(exportDir);
+            }
+        }
+
+        [Fact]
+        public async Task Csv_ClassicPages_HasEnrichedColumns()
+        {
+            var scanId = Guid.NewGuid();
+            var siteUrl = $"https://contoso.sharepoint.com/sites/{scanId:N}";
+            var pageUrl = "/SitePages/Home.aspx";
+
+            var page = new ClassicPage
+            {
+                ScanId = scanId,
+                SiteUrl = siteUrl,
+                WebUrl = siteUrl,
+                PageUrl = pageUrl,
+                PageName = "Home.aspx",
+                PageType = "WikiPage",
+                RemediationCode = "CP2",
+                Layout = "TwoColumns",
+                HomePage = true,
+                UncustomizedHomePage = true,
+                ModifiedBy = "jane@contoso.com",
+                WebPartCount = 4,
+                MappingPercentage = 75,
+                UnmappedWebParts = "ContosoCustomWebPart",
+            };
+
+            using (var context = fixture.CreateContext())
+            {
+                await context.ClassicPages.AddAsync(page);
+                await context.SaveChangesAsync();
+            }
+
+            var exportDir = NewTempDir();
+            try
+            {
+                await ExportAsync(scanId, exportDir);
+
+                var file = Path.Join(exportDir, "classicpages.csv");
+                File.Exists(file).Should().BeTrue();
+
+                // The enrichment columns the page scan adds must all surface in the page CSV.
+                ReadHeader(file).Should().Contain(new[]
+                {
+                    nameof(ClassicPage.Layout),
+                    nameof(ClassicPage.HomePage),
+                    nameof(ClassicPage.UncustomizedHomePage),
+                    nameof(ClassicPage.ModifiedBy),
+                    nameof(ClassicPage.WebPartCount),
+                    nameof(ClassicPage.MappingPercentage),
+                    nameof(ClassicPage.UnmappedWebParts),
+                });
+
+                var row = ReadRecords<ClassicPage>(file).Single(p => p.ScanId == scanId && p.PageUrl == pageUrl);
+
+                row.Layout.Should().Be("TwoColumns");
+                row.HomePage.Should().BeTrue();
+                row.UncustomizedHomePage.Should().BeTrue();
+                row.ModifiedBy.Should().Be("jane@contoso.com");
+                row.WebPartCount.Should().Be(4);
+                row.MappingPercentage.Should().Be(75);
+                row.UnmappedWebParts.Should().Be("ContosoCustomWebPart");
+            }
+            finally
+            {
+                DeleteTempDir(exportDir);
+            }
+        }
+
+        private async Task ExportAsync(Guid scanId, string exportDir)
+        {
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = "," };
+            using var context = fixture.CreateContext();
+            await ReportManager.ExportClassicReportDataAsync(context, scanId, exportDir, config);
+        }
+
+        private static string[] ReadHeader(string file)
+        {
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = "," };
+            using var reader = new StreamReader(file);
+            using var csv = new CsvReader(reader, config);
+            csv.Read();
+            csv.ReadHeader();
+            return csv.HeaderRecord;
+        }
+
+        private static List<T> ReadRecords<T>(string file)
+        {
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = "," };
+            using var reader = new StreamReader(file);
+            using var csv = new CsvReader(reader, config);
+            return csv.GetRecords<T>().ToList();
+        }
+
+        private static string NewTempDir()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "pnp-t11-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static void DeleteTempDir(string dir)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; a leaked temp dir must not fail the test.
+            }
+        }
+
+        private static ClassicPageWebPart NewWebPart(Guid scanId, string siteUrl, string pageUrl, int index,
+                                                     string type, string shortType, bool isMappable)
+        {
+            return new ClassicPageWebPart
+            {
+                ScanId = scanId,
+                SiteUrl = siteUrl,
+                WebUrl = siteUrl,
+                PageUrl = pageUrl,
+                WebPartIndex = index,
+                WebPartType = type,
+                WebPartTypeShort = shortType,
+                WebPartTitle = $"Web part {index}",
+                ZoneId = "Header",
+                Row = 1,
+                Column = 2,
+                Order = index,
+                Hidden = false,
+                IsClosed = false,
+                IsMappable = isMappable,
+            };
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Services/ReportManager.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Services/ReportManager.cs
@@ -32,6 +32,8 @@ namespace PnP.Scanning.Core.Services
 
         private const string ClassicInfoPathCsv = "classicinfopath.csv";
         private const string ClassicPagesCsv = "classicpages.csv";
+        private const string ClassicPageWebPartsCsv = "classicpagewebparts.csv";
+        private const string ClassicWebPartUniqueCsv = "classicwebpartunique.csv";
         private const string ClassicListsCsv = "classiclists.csv";
         private const string ClassicUserCustomActionsCsv = "classicusercustomactions.csv";
         private const string ClassicExtensibilitiesCsv = "classicextensibilities.csv";
@@ -296,69 +298,7 @@ namespace PnP.Scanning.Core.Services
 
                 if (scan.CLIMode == Mode.Classic.ToString())
                 {
-                    using (var writer = new StreamWriter(Path.Join(exportPath, WorkflowsCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.Workflows.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicExtensibilitiesCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicExtensibilities.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicInfoPathCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicInfoPath.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicListsCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicLists.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicPagesCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicPages.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicUserCustomActionsCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicUserCustomActions.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicSiteSummariesCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicSiteSummaries.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
-
-                    using (var writer = new StreamWriter(Path.Join(exportPath, ClassicWebSummariesCsv)))
-                    {
-                        using (var csv = new CsvWriter(writer, config))
-                        {
-                            await csv.WriteRecordsAsync(dbContext.ClassicWebSummaries.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
-                        }
-                    }
+                    await ExportClassicReportDataAsync(dbContext, scanId, exportPath, config);
                 }
 
                 if (scan.CLIMode == Mode.InfoPath.ToString())
@@ -443,6 +383,96 @@ namespace PnP.Scanning.Core.Services
             }
 
             return exportPath;
+        }
+
+        /// <summary>
+        /// Exports the Classic scan-mode tables to CSV. Split out from <see cref="ExportReportDataAsync"/>
+        /// as a testable static core (same pattern as the StorageManager rollup cores) so the page-scan
+        /// exports — including the T11 <c>classicpagewebparts.csv</c> / <c>classicwebpartunique.csv</c> and
+        /// the enriched <c>classicpages.csv</c> — can be exercised against a seeded in-memory SQLite
+        /// <see cref="ScanContext"/> without opening an on-disk scan database.
+        /// </summary>
+        internal static async Task ExportClassicReportDataAsync(ScanContext dbContext, Guid scanId, string exportPath, CsvConfiguration config)
+        {
+            using (var writer = new StreamWriter(Path.Join(exportPath, WorkflowsCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.Workflows.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicExtensibilitiesCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicExtensibilities.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicInfoPathCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicInfoPath.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicListsCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicLists.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicPagesCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicPages.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicPageWebPartsCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicPageWebParts.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicWebPartUniqueCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicWebPartUniques.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicUserCustomActionsCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicUserCustomActions.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicSiteSummariesCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicSiteSummaries.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
+
+            using (var writer = new StreamWriter(Path.Join(exportPath, ClassicWebSummariesCsv)))
+            {
+                using (var csv = new CsvWriter(writer, config))
+                {
+                    await csv.WriteRecordsAsync(dbContext.ClassicWebSummaries.Where(p => p.ScanId == scanId).AsAsyncEnumerable());
+                }
+            }
         }
 
         private static string EnsureReportPath(Guid scanId, string exportPath)


### PR DESCRIPTION
## What

Adds the Classic page-scan CSV exports — the reporting half of the classic-page
transformation-readiness work (T11 of the classic-page-scan backlog).

- New **`classicpagewebparts.csv`** — per-page web part inventory (`ClassicPageWebParts`),
  parity with the old Modernization Scanner's per-web-part output.
- New **`classicwebpartunique.csv`** — scan-wide unique web part inventory
  (`ClassicWebPartUniques`), parity with the legacy `UniqueWebParts.csv` plus the
  `PageCount` enhancement.
- The enriched **`classicpages.csv`** columns (Layout, HomePage, UncustomizedHomePage,
  ModifiedBy, WebPartCount, MappingPercentage, UnmappedWebParts) export automatically —
  CsvHelper writes property names as the header, no `ClassMap` change.

## How

Extracted the whole `Mode.Classic` block of `ReportManager.ExportReportDataAsync` into a
testable static core:

```csharp
internal static Task ExportClassicReportDataAsync(
    ScanContext dbContext, Guid scanId, string exportPath, CsvConfiguration config)
```

The public ExportReportDataAsync opens the on-disk scan DB via
GetScanContextForDataExportAsync(scanId), so it can't be unit-tested directly. The core
takes a ScanContext, which lets the UTs seed the in-memory SQLite fixture, export to a temp
dir, and re-read with CsvHelper. Same split pattern as the T8/T9 StorageManager rollup
cores. The Scan-status gate stays in the caller.

RewriteDataLocationsInPbit is unchanged: it generically rewrites the authoring directory
prefix + delimiter in the .pbit's DataModelSchema, not a per-file list, so new CSVs in the
same export folder are picked up automatically once the template references them — that (and
its rewrite UT) is T12's work.

Tests

Tests/Storage/ClassicReportExportTests.cs (3 new):

- Csv_PageWebParts_HeaderAndRows — 15-column header schema + row values
(type/short type/zone/row/column/mappable).
- Csv_WebPartUnique_HeaderAndRows — 4-column header + InMappingFile/PageCount.
- Csv_ClassicPages_HasEnrichedColumns — asserts the 7 enrichment columns are in the
header and round-trip their values.

Each seeds the shared in-memory ScanContext fixture, exports to a temp dir, re-reads with
CsvHelper. Full suite green: 117 tests (+3).