### PR TITLE
Make Power BI .pbit data-location rewrite testable + add rewrite UTs

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/PbitRewriteTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/PbitRewriteTests.cs
@@ -1,0 +1,146 @@
+﻿using System.IO.Compression;
+using System.Text;
+using FluentAssertions;
+using PnP.Scanning.Core.Services;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Storage
+{
+    /// <summary>
+    /// T12 — verifies the Power BI <c>.pbit</c> data-location rewrite
+    /// (<see cref="ReportManager.RewriteDataLocationsInPbit"/>). The rewrite is what makes the
+    /// generated report point at the freshly exported CSVs instead of the hard-coded authoring
+    /// directory the template was created against. The <c>.pbit</c> visuals themselves are a binary
+    /// Power BI template (manual-verify only — no unit test), but the path/delimiter rewrite is pure
+    /// file logic and is exercised here against a hand-built fixture template containing the new
+    /// T11 page-scan CSV data sources (<c>classicpagewebparts.csv</c> / <c>classicwebpartunique.csv</c>).
+    /// </summary>
+    public class PbitRewriteTests
+    {
+        // The literal directory prefix the Classic template references at authoring time, exactly as
+        // passed by ReportManager.CreatePowerBiReportAsync. Inside the DataModelSchema's JSON-escaped M
+        // code the backslashes are doubled, so the runtime string value carries doubled backslashes too.
+        private const string OldLocation = "q:\\\\github\\\\pnpassessment\\\\src\\\\PnP.Scanning\\\\Reports\\\\Classic\\\\";
+
+        [Fact]
+        public void RewriteDataLocationsInPbit_NewCsvSources_PathsRewritten()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                // A fixture DataModelSchema referencing the existing page CSV plus the two new
+                // T11 page-scan sources, all under the authoring-time directory prefix.
+                var schema = string.Join("\r\n", new[]
+                {
+                    SourceLine("classicpages.csv", "11"),
+                    SourceLine("classicpagewebparts.csv", "15"),
+                    SourceLine("classicwebpartunique.csv", "4"),
+                });
+
+                var pbit = BuildFixturePbit(dir, schema);
+
+                // Rewrite exactly as the Classic branch of CreatePowerBiReportAsync does: same old
+                // location, delimiter unchanged (",").
+                ReportManager.RewriteDataLocationsInPbit(pbit, ",", OldLocation, ",");
+
+                var rewritten = ReadDataModelSchema(pbit);
+
+                // The hard-coded authoring directory prefix is gone...
+                rewritten.Should().NotContain("q:\\\\github");
+
+                // ...replaced by the .pbit's own directory (backslashes doubled, trailing separator),
+                // and the new CSV sources now resolve against that export directory.
+                var newPrefix = dir.Replace("\\", "\\\\") + "\\\\";
+                rewritten.Should().Contain(newPrefix + "classicpages.csv");
+                rewritten.Should().Contain(newPrefix + "classicpagewebparts.csv");
+                rewritten.Should().Contain(newPrefix + "classicwebpartunique.csv");
+            }
+            finally
+            {
+                DeleteTempDir(dir);
+            }
+        }
+
+        [Fact]
+        public void RewriteDataLocationsInPbit_NewDelimiter_DelimiterRewritten()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var schema = SourceLine("classicpagewebparts.csv", "15");
+                var pbit = BuildFixturePbit(dir, schema);
+
+                // Caller chose ";" as the export delimiter; the template was authored with ",".
+                ReportManager.RewriteDataLocationsInPbit(pbit, ";", OldLocation, ",");
+
+                var rewritten = ReadDataModelSchema(pbit);
+
+                rewritten.Should().Contain("Delimiter=\\\";\\\"");
+                rewritten.Should().NotContain("Delimiter=\\\",\\\"");
+            }
+            finally
+            {
+                DeleteTempDir(dir);
+            }
+        }
+
+        // One DataModelSchema M "Source" line for a CSV, mirroring the real template's JSON-escaped form:
+        //   Source = Csv.Document(File.Contents("q:\\github\\...\\Classic\\<csv>"),[Delimiter=",", ...]),
+        private static string SourceLine(string csv, string columns)
+        {
+            return $"    Source = Csv.Document(File.Contents(\\\"{OldLocation}{csv}\\\")," +
+                   $"[Delimiter=\\\",\\\", Columns={columns}, Encoding=1252, QuoteStyle=QuoteStyle.None]),";
+        }
+
+        // Builds a minimal valid .pbit (a zip) in its own directory containing a single
+        // "DataModelSchema" entry. The real template stores that entry as UTF-16 (Unicode), which is
+        // how RewriteDataLocationsInPbit reads it back, so the fixture is written the same way.
+        private static string BuildFixturePbit(string dir, string dataModelSchema)
+        {
+            var pbit = Path.Combine(dir, "ClassicAssessmentReport.pbit");
+
+            using (var archive = ZipFile.Open(pbit, ZipArchiveMode.Create))
+            {
+                var entry = archive.CreateEntry("DataModelSchema");
+                using var entryStream = entry.Open();
+                var bytes = new UnicodeEncoding(bigEndian: false, byteOrderMark: true).GetBytes(dataModelSchema);
+                entryStream.Write(bytes, 0, bytes.Length);
+            }
+
+            return pbit;
+        }
+
+        private static string ReadDataModelSchema(string pbit)
+        {
+            using var archive = ZipFile.OpenRead(pbit);
+            var entry = archive.GetEntry("DataModelSchema");
+            entry.Should().NotBeNull();
+
+            using var stream = entry.Open();
+            using var reader = new StreamReader(stream, Encoding.Unicode);
+            return reader.ReadToEnd();
+        }
+
+        private static string NewTempDir()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "pnp-t12-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static void DeleteTempDir(string dir)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; a leaked temp dir must not fail the test.
+            }
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Services/ReportManager.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Services/ReportManager.cs
@@ -505,7 +505,7 @@ namespace PnP.Scanning.Core.Services
             }
         }
 
-        private static void RewriteDataLocationsInPbit(string pbitFile, string newDelimiter, string oldLocation, string oldDelimiter)
+        internal static void RewriteDataLocationsInPbit(string pbitFile, string newDelimiter, string oldLocation, string oldDelimiter)
         {
             string destinationPath = "";
             string copiedFile = "";


### PR DESCRIPTION
## What

Implements the **automatable half of T12** (Power BI `.pbit` update) from the classic-page-scan
backlog: makes the `.pbit` data-location rewrite unit-testable and ships the rewrite UTs. The binary
`.pbit` visual authoring is a manual Power BI Desktop step (see *Out of scope*).

## Changes

- **`Services/ReportManager.cs`** — `RewriteDataLocationsInPbit` changed `private static` →
  `internal static` so the test project (`InternalsVisibleTo` already present) can exercise it.
  **No behavior change.** The rewrite is generic: it swaps the hard-coded authoring-time directory
  prefix + CSV delimiter inside the `.pbit`'s `DataModelSchema`, so the new T11 page-scan CSVs
  (`classicpagewebparts.csv` / `classicwebpartunique.csv`) are picked up automatically once the
  template references them — confirming the T11 finding that no per-file change was needed here.

- **`Tests/Storage/PbitRewriteTests.cs`** (new, 2 tests):
  - `RewriteDataLocationsInPbit_NewCsvSources_PathsRewritten` — builds a fixture `.pbit` (zip with a
    UTF-16 `DataModelSchema` entry) containing M `Source` lines for `classicpages.csv` plus the two
    new page-scan CSVs under the authoring prefix `q:\github\…\Reports\Classic\`, runs the rewrite
    exactly as the Classic report branch of `CreatePowerBiReportAsync` does, then re-opens the zip and
    asserts the `q:\github` prefix is gone and all three CSVs now resolve against the export directory.
  - `RewriteDataLocationsInPbit_NewDelimiter_DelimiterRewritten` — covers the delimiter swap
    (`Delimiter=","` → `Delimiter=";"`).

  The fixture mirrors the shipped template's JSON-escaped `Csv.Document(File.Contents(...))` format
  verbatim so the escaping is exact.

## Testing

`dotnet test PnP.Scanning.Core.Tests` — **119 passing (+2)**, no regressions.

## Out of scope (manual follow-up)

The `.pbit` visuals are a binary Power BI Desktop template and are **manual-verify only** by design.
Remaining manual step: open `Reports/Classic/ClassicAssessmentReport.pbit`, add the two new CSVs as
data sources, add a **"Classic Page Readiness"** report page (pages-by-mapping-%, unmapped-web-part
pivot, web-part inventory), re-save against the same authoring prefix, and copy over the
embedded-resource copy under `PnP.Scanning.Core`.