### PR TITLE
Classic page usage statistics (recent/lifetime views) via per-page search

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageUsageAnalyzerTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Scanners/Pages/PageUsageAnalyzerTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using PnP.Scanning.Core.Storage;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Scanners.Pages
+{
+    /// <summary>
+    /// T13 — the pure page-usage parsing/mapping (recent + lifetime views and their unique-user counts).
+    /// The live CSOM search query (<c>PageUsageAnalyzer.QueryPageUsageAsync</c>) is integration-only
+    /// (→ T15); here only the row parsing, the skip-usage gate and the search-path builder are covered.
+    /// </summary>
+    public class PageUsageAnalyzerTests
+    {
+        private static Dictionary<string, string> SearchRow(
+            string recent = "10", string recentUsers = "4", string lifeTime = "123", string lifeTimeUsers = "45")
+        {
+            return new Dictionary<string, string>
+            {
+                ["OriginalPath"] = "https://contoso.sharepoint.com/sites/foo/SitePages/Page.aspx",
+                ["ViewsRecent"] = recent,
+                ["ViewsRecentUniqueUsers"] = recentUsers,
+                ["ViewsLifeTime"] = lifeTime,
+                ["ViewsLifeTimeUniqueUsers"] = lifeTimeUsers,
+            };
+        }
+
+        [Fact]
+        public void Usage_ParseSearchRow_MapsViewFields()
+        {
+            var usage = PageUsageAnalyzer.ParseSearchRow(SearchRow());
+
+            usage.ViewsRecent.Should().Be(10);
+            usage.ViewsRecentUniqueUsers.Should().Be(4);
+            usage.ViewsLifeTime.Should().Be(123);
+            usage.ViewsLifeTimeUniqueUsers.Should().Be(45);
+        }
+
+        [Fact]
+        public void Usage_ApplyUsage_MapsViewFieldsOntoPage()
+        {
+            var page = new ClassicPage();
+
+            PageUsageAnalyzer.ApplyUsage(page, SearchRow(), skipUsageInformation: false);
+
+            page.ViewsRecent.Should().Be(10);
+            page.ViewsRecentUniqueUsers.Should().Be(4);
+            page.ViewsLifeTime.Should().Be(123);
+            page.ViewsLifeTimeUniqueUsers.Should().Be(45);
+        }
+
+        [Fact]
+        public void Usage_SkipUsageInformation_LeavesZero()
+        {
+            // With the skip flag set the view columns stay at their default 0 even when a row is supplied.
+            var page = new ClassicPage();
+
+            PageUsageAnalyzer.ApplyUsage(page, SearchRow(), skipUsageInformation: true);
+
+            page.ViewsRecent.Should().Be(0);
+            page.ViewsRecentUniqueUsers.Should().Be(0);
+            page.ViewsLifeTime.Should().Be(0);
+            page.ViewsLifeTimeUniqueUsers.Should().Be(0);
+        }
+
+        [Fact]
+        public void Usage_ApplyUsage_NullRow_LeavesZero()
+        {
+            // A page that is not in the search index yields no row → counts stay 0.
+            var page = new ClassicPage();
+
+            PageUsageAnalyzer.ApplyUsage(page, null, skipUsageInformation: false);
+
+            page.ViewsRecent.Should().Be(0);
+            page.ViewsRecentUniqueUsers.Should().Be(0);
+            page.ViewsLifeTime.Should().Be(0);
+            page.ViewsLifeTimeUniqueUsers.Should().Be(0);
+        }
+
+        [Fact]
+        public void Usage_ParseSearchRow_MissingOrEmptyValues_DefaultToZero()
+        {
+            var row = new Dictionary<string, string>
+            {
+                ["ViewsRecent"] = "",               // empty
+                ["ViewsLifeTime"] = "not-a-number", // unparseable
+                // ViewsRecentUniqueUsers / ViewsLifeTimeUniqueUsers absent entirely
+            };
+
+            var usage = PageUsageAnalyzer.ParseSearchRow(row);
+
+            usage.ViewsRecent.Should().Be(0);
+            usage.ViewsRecentUniqueUsers.Should().Be(0);
+            usage.ViewsLifeTime.Should().Be(0);
+            usage.ViewsLifeTimeUniqueUsers.Should().Be(0);
+        }
+
+        [Fact]
+        public void BuildPageSearchPath_RegularPage_PrefixesSiteAuthority()
+        {
+            // A regular page is looked up by its absolute URL (site authority + server-relative page path).
+            string path = PageUsageAnalyzer.BuildPageSearchPath(
+                "https://contoso.sharepoint.com/sites/foo", "/subweb", "/sites/foo/subweb/SitePages/Page.aspx", isHomePage: false);
+
+            path.Should().Be("https://contoso.sharepoint.com/sites/foo/subweb/SitePages/Page.aspx");
+        }
+
+        [Fact]
+        public void BuildPageSearchPath_HomePage_UsesWebUrl()
+        {
+            // The home page is indexed under the web URL itself, not its SitePages/...aspx path.
+            string path = PageUsageAnalyzer.BuildPageSearchPath(
+                "https://contoso.sharepoint.com/sites/foo", "/subweb", "/sites/foo/subweb/SitePages/Home.aspx", isHomePage: true);
+
+            path.Should().Be("https://contoso.sharepoint.com/sites/foo/subweb");
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
@@ -158,6 +158,27 @@ namespace PnP.Scanning.Core.Scanners
                 }
             }
 
+            // Page usage statistics (recent / lifetime views + unique users) via a per-page search lookup,
+            // unless the caller opted out. Applies to every classic page, not only those carrying a web
+            // part inventory. The per-page lookup (RowLimit 1) deliberately avoids the legacy bulk-search
+            // IndexDocId paging risk. Per-page failures are logged and skipped (view counts stay zero).
+            if (!options.SkipUsageInformation)
+            {
+                foreach (var page in pagesList)
+                {
+                    try
+                    {
+                        string searchPath = PageUsageAnalyzer.BuildPageSearchPath(scannerBase.SiteUrl, scannerBase.WebUrl, page.PageUrl, page.HomePage);
+                        var usageRow = await PageUsageAnalyzer.QueryPageUsageAsync(csomContext, searchPath).ConfigureAwait(false);
+                        PageUsageAnalyzer.ApplyUsage(page, usageRow, options.SkipUsageInformation);
+                    }
+                    catch (Exception ex)
+                    {
+                        scannerBase.Logger.Warning(ex, "Failed to retrieve usage statistics for classic page {PageUrl}; leaving view counts at zero", page.PageUrl);
+                    }
+                }
+            }
+
             if (pagesList.Count > 0)
             {
                 await scannerBase.StorageManager.StorePageInformationAsync(scannerBase.ScanId, pagesList);

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageUsageAnalyzer.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/Pages/PageUsageAnalyzer.cs
@@ -1,0 +1,159 @@
+﻿using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.Search.Query;
+using PnP.Scanning.Core.Storage;
+
+namespace PnP.Scanning.Core.Scanners
+{
+    /// <summary>
+    /// Fills a classic page's usage statistics (recent / lifetime views and their unique-user counts)
+    /// from SharePoint search, mirroring the legacy Modernization Scanner (its <c>ViewsRecent</c> /
+    /// <c>ViewsLifeTime</c> managed-property merge in <c>PageAnalyzer</c>).
+    /// <para>
+    /// The legacy scanner ran a single bulk search per site collection and paged the results on
+    /// <c>IndexDocId</c> — the source of a known paging failure on some tenants
+    /// (see <c>modernization-scanner-indexdocid-search-paging</c>). That risk belonged to <b>discovery</b>,
+    /// which the new engine performs over REST and did not port. Here usage is a <b>per-page lookup</b>
+    /// (<see cref="QueryPageUsageAsync"/> with <c>RowLimit 1</c>), so there is no deep paging and the
+    /// IndexDocId risk does not apply.
+    /// </para>
+    /// <para>
+    /// Only the row parsing (<see cref="ParseSearchRow"/>), the skip-usage gate (<see cref="ApplyUsage"/>)
+    /// and the search-path builder (<see cref="BuildPageSearchPath"/>) are pure and unit-tested; the live
+    /// CSOM search query (<see cref="QueryPageUsageAsync"/>) is integration-only (→ T15).
+    /// </para>
+    /// </summary>
+    internal static class PageUsageAnalyzer
+    {
+        // Local SharePoint Results result source (the well-known id the legacy scanner used) so the usage
+        // query runs against the local search index.
+        private static readonly Guid LocalSharePointResultsSourceId = new("8413cd39-2156-4e00-b54d-11efd9abdb89");
+
+        // Managed properties carrying the page view statistics.
+        internal const string OriginalPathProperty = "OriginalPath";
+        internal const string ViewsRecentProperty = "ViewsRecent";
+        internal const string ViewsRecentUniqueUsersProperty = "ViewsRecentUniqueUsers";
+        internal const string ViewsLifeTimeProperty = "ViewsLifeTime";
+        internal const string ViewsLifeTimeUniqueUsersProperty = "ViewsLifeTimeUniqueUsers";
+
+        // The managed properties requested from search for a page.
+        internal static readonly IReadOnlyList<string> PropertiesToRetrieve = new[]
+        {
+            OriginalPathProperty,
+            ViewsRecentProperty,
+            ViewsRecentUniqueUsersProperty,
+            ViewsLifeTimeProperty,
+            ViewsLifeTimeUniqueUsersProperty,
+        };
+
+        /// <summary>The four view counts parsed from a single search result row.</summary>
+        internal readonly record struct PageUsageStatistics(
+            int ViewsRecent, int ViewsRecentUniqueUsers, int ViewsLifeTime, int ViewsLifeTimeUniqueUsers);
+
+        /// <summary>
+        /// Pure: maps a search result row (managed property name → string value) onto the four view counts.
+        /// A missing, empty or non-numeric value yields 0 (parity with the legacy <c>ToInt32()</c> merge).
+        /// </summary>
+        internal static PageUsageStatistics ParseSearchRow(IReadOnlyDictionary<string, string> searchRow)
+        {
+            if (searchRow == null)
+            {
+                return default;
+            }
+
+            return new PageUsageStatistics(
+                ParseViewCount(searchRow, ViewsRecentProperty),
+                ParseViewCount(searchRow, ViewsRecentUniqueUsersProperty),
+                ParseViewCount(searchRow, ViewsLifeTimeProperty),
+                ParseViewCount(searchRow, ViewsLifeTimeUniqueUsersProperty));
+        }
+
+        /// <summary>
+        /// Pure: applies the parsed usage statistics to <paramref name="page"/>, unless usage information
+        /// is skipped or no search row was found — in either case the view columns are left at their
+        /// default 0.
+        /// </summary>
+        internal static void ApplyUsage(ClassicPage page, IReadOnlyDictionary<string, string> searchRow, bool skipUsageInformation)
+        {
+            ArgumentNullException.ThrowIfNull(page);
+
+            if (skipUsageInformation || searchRow == null)
+            {
+                return;
+            }
+
+            var usage = ParseSearchRow(searchRow);
+            page.ViewsRecent = usage.ViewsRecent;
+            page.ViewsRecentUniqueUsers = usage.ViewsRecentUniqueUsers;
+            page.ViewsLifeTime = usage.ViewsLifeTime;
+            page.ViewsLifeTimeUniqueUsers = usage.ViewsLifeTimeUniqueUsers;
+        }
+
+        /// <summary>
+        /// Pure: builds the absolute page URL used to look a page up in search. The home page is indexed
+        /// under the web URL itself (not its <c>SitePages/...aspx</c> path), matching the legacy scanner;
+        /// any other page's server-relative <paramref name="pageUrl"/> is prefixed with the site authority.
+        /// </summary>
+        internal static string BuildPageSearchPath(string siteUrl, string webUrl, string pageUrl, bool isHomePage)
+        {
+            if (isHomePage)
+            {
+                return $"{siteUrl}{webUrl}";
+            }
+
+            // pageUrl is server-relative (e.g. /sites/foo/SitePages/Page.aspx); prefix the site authority.
+            string authority = new Uri(siteUrl).GetLeftPart(UriPartial.Authority);
+            return $"{authority}{pageUrl}";
+        }
+
+        private static int ParseViewCount(IReadOnlyDictionary<string, string> row, string property)
+        {
+            if (row.TryGetValue(property, out var value) && int.TryParse(value, out var parsed))
+            {
+                return parsed;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Integration-only (exercised by the T15 live test): runs a per-page search lookup and returns the
+        /// requested managed property values as a row dictionary, or <c>null</c> when the page is not in the
+        /// search index. A per-page lookup (<c>RowLimit 1</c>) deliberately avoids the legacy bulk-search
+        /// IndexDocId paging risk.
+        /// </summary>
+        internal static async Task<IReadOnlyDictionary<string, string>> QueryPageUsageAsync(ClientContext csomContext, string searchPath)
+        {
+            var keywordQuery = new KeywordQuery(csomContext)
+            {
+                QueryText = $"path={searchPath} AND fileextension=aspx",
+                RowLimit = 1,
+                TrimDuplicates = false,
+                SourceId = LocalSharePointResultsSourceId,
+            };
+
+            foreach (var property in PropertiesToRetrieve)
+            {
+                keywordQuery.SelectProperties.Add(property);
+            }
+
+            var searchExecutor = new SearchExecutor(csomContext);
+            var results = searchExecutor.ExecuteQuery(keywordQuery);
+            await csomContext.ExecuteQueryAsync().ConfigureAwait(false);
+
+            var table = results.Value?.FirstOrDefault();
+            if (table == null || table.RowCount == 0)
+            {
+                return null;
+            }
+
+            var firstRow = table.ResultRows.First();
+            var row = new Dictionary<string, string>();
+            foreach (var property in PropertiesToRetrieve)
+            {
+                row[property] = firstRow.TryGetValue(property, out var value) && value != null ? value.ToString() : "";
+            }
+
+            return row;
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds page **usage statistics** (recent + lifetime view counts and their unique-user
counts) to the Classic page scan, the last data-enrichment gap from the Modernization
Scanner. Fills `ClassicPage.ViewsRecent / ViewsRecentUniqueUsers / ViewsLifeTime /
ViewsLifeTimeUniqueUsers`, gated by `--skipusageinformation`.

Part of the classic-page-scan merge (T13 of the backlog). Columns already exist from
T1, so **no migration**.

## How

New pure module `Scanners/Classic/Pages/PageUsageAnalyzer.cs`:

- `ParseSearchRow(row)` → `PageUsageStatistics` — maps the four search managed
  properties to ints (missing / empty / non-numeric → 0, matching the legacy
  `.ToInt32()` merge).
- `ApplyUsage(page, row, skipUsageInformation)` — stamps the four `Views*` columns;
  a set skip flag **or** a null row (page not in the index) leaves them at 0.
- `BuildPageSearchPath(...)` — the absolute lookup URL (home page → web URL; other
  pages → site-authority + server-relative path).
- `QueryPageUsageAsync(...)` — **integration-only (→ T15)**: the live CSOM search.

Wired into `PageScanComponent.ExecuteAsync` after the web-part enrichment loop and
before `StorePageInformationAsync`: a `!SkipUsageInformation`-gated loop over every
discovered page calls `BuildPageSearchPath → QueryPageUsageAsync → ApplyUsage`.
Per-page failures are logged and skipped (counts stay 0), same policy as the web-part
loop.

## Design decision — per-page lookup, not the legacy bulk search

The legacy scanner ran **one search per site collection** and paged results on
`IndexDocId` — the source of a known paging failure on some tenants. That risk belonged
to *discovery*, which the new engine does over REST. Usage is the only thing left that
needs search, so it's done as a **per-page lookup** (`KeywordQuery`, `RowLimit 1`,
Local SharePoint Results source): one row per page, **no IndexDocId paging**, so that
risk doesn't apply. Trade-off: more search round-trips (rides the existing
rate-limiter/retry).

Uses `Microsoft.SharePoint.Client.Search.Query` from the already-referenced
`Microsoft.SharePointOnline.CSOM` — no new package.

## Parity notes

- **Data captured is at parity:** same four managed properties, same parse, same skip
  semantics, same result source as the old scanner.
- **Deviation:** per-page query drops the legacy `contentclass=…` clause (exact path
  already disambiguates a regular page).
- **Unverified until T15:** the exact KQL for the **home page** — legacy partly matched
  it via `contentclass=STS_Site/STS_Web`; the per-page query keeps `fileextension=aspx`
  on the web URL, which may need tuning against a real index. This is why the live query
  is integration-only.

## Tests

`Tests/Scanners/Pages/PageUsageAnalyzerTests.cs` (7) — `Usage_ParseSearchRow_MapsViewFields`,
`Usage_ApplyUsage_MapsViewFieldsOntoPage`, `Usage_SkipUsageInformation_LeavesZero`,
`Usage_ApplyUsage_NullRow_LeavesZero`, `Usage_ParseSearchRow_MissingOrEmptyValues_DefaultToZero`,
`BuildPageSearchPath_RegularPage_PrefixesSiteAuthority`, `BuildPageSearchPath_HomePage_UsesWebUrl`.