### PR TITLE
Classic page-scan telemetry (page type distribution + transformation readiness)

### DIFF
--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Services/TelemetryManagerTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Services/TelemetryManagerTests.cs
@@ -1,0 +1,149 @@
+﻿using FluentAssertions;
+using PnP.Scanning.Core.Scanners;
+using PnP.Scanning.Core.Services;
+using PnP.Scanning.Core.Storage;
+using PnP.Scanning.Core.Tests.Fixtures;
+using Xunit;
+
+namespace PnP.Scanning.Core.Tests.Services
+{
+    /// <summary>
+    /// T14 — verifies the classic page-scan telemetry payload built by
+    /// <see cref="TelemetryManager.BuildClassicMetrics"/> (page type distribution + page
+    /// transformation readiness). Payload construction only — no Application Insights / network.
+    /// Each test owns a fresh in-memory <see cref="ScanContext"/>, mirroring the one-database-per-scan
+    /// production layout the metric builder iterates over (it is not scan-id filtered).
+    /// </summary>
+    public class TelemetryManagerTests
+    {
+        [Fact]
+        public void Telemetry_LogPageScan_BuildsExpectedPayload()
+        {
+            using var fixture = new ScanContextFixture();
+            var scanId = Guid.NewGuid();
+            var siteUrl = $"https://contoso.sharepoint.com/sites/{scanId:N}";
+
+            // One page per classic type; three carry web parts (75 / 100 / 50), three carry none.
+            // The ASPX page is the (uncustomized) home page.
+            var pages = new List<ClassicPage>
+            {
+                NewPage(scanId, siteUrl, "/Pages/a.aspx", PageScanComponent.WikiPage, webPartCount: 4, mappingPercentage: 75),
+                NewPage(scanId, siteUrl, "/Pages/b.aspx", PageScanComponent.WebPartPage, webPartCount: 2, mappingPercentage: 100),
+                NewPage(scanId, siteUrl, "/Pages/c.aspx", PageScanComponent.PublishingPage, webPartCount: 3, mappingPercentage: 50),
+                NewPage(scanId, siteUrl, "/Lists/Posts/d.aspx", PageScanComponent.BlogPage, webPartCount: 0, mappingPercentage: 100),
+                NewPage(scanId, siteUrl, "/default.aspx", PageScanComponent.ASPXPage, webPartCount: 0, mappingPercentage: 100,
+                        homePage: true, uncustomizedHomePage: true),
+                NewPage(scanId, siteUrl, "/Lists/Posts/f.aspx", PageScanComponent.DelveBlogPage, webPartCount: 0, mappingPercentage: 100),
+            };
+
+            // Five web part rows total across the three pages that carry parts.
+            var webParts = new List<ClassicPageWebPart>
+            {
+                NewWebPart(scanId, siteUrl, "/Pages/a.aspx", 0, "ContentEditorWebPart"),
+                NewWebPart(scanId, siteUrl, "/Pages/a.aspx", 1, "ContentEditorWebPart"),
+                NewWebPart(scanId, siteUrl, "/Pages/b.aspx", 0, "XsltListViewWebPart"),
+                NewWebPart(scanId, siteUrl, "/Pages/c.aspx", 0, "Contoso.Custom.WebPart"),
+                NewWebPart(scanId, siteUrl, "/Pages/c.aspx", 1, "Contoso.Custom.WebPart"),
+            };
+
+            // Scan-wide unique inventory: 2 mapped types, 1 unmapped type.
+            var uniques = new List<ClassicWebPartUnique>
+            {
+                new() { ScanId = scanId, WebPartType = "ContentEditorWebPart", InMappingFile = true, PageCount = 1 },
+                new() { ScanId = scanId, WebPartType = "XsltListViewWebPart", InMappingFile = true, PageCount = 1 },
+                new() { ScanId = scanId, WebPartType = "Contoso.Custom.WebPart", InMappingFile = false, PageCount = 1 },
+            };
+
+            using (var context = fixture.CreateContext())
+            {
+                context.ClassicPages.AddRange(pages);
+                context.ClassicPageWebParts.AddRange(webParts);
+                context.ClassicWebPartUniques.AddRange(uniques);
+                context.SaveChanges();
+            }
+
+            var metric = new Dictionary<string, double>();
+            using (var context = fixture.CreateContext())
+            {
+                TelemetryManager.BuildClassicMetrics(context, metric);
+            }
+
+            // Page type distribution
+            metric["ClassicPageCount"].Should().Be(6);
+            metric["ClassicPageWikiCount"].Should().Be(1);
+            metric["ClassicPageWebPartPageCount"].Should().Be(1);
+            metric["ClassicPageASPXCount"].Should().Be(1);
+            metric["ClassicPagePublishingCount"].Should().Be(1);
+            metric["ClassicPageBlogCount"].Should().Be(1);
+            metric["ClassicPageDelveBlogCount"].Should().Be(1);
+
+            // Home pages
+            metric["ClassicPageHomePageCount"].Should().Be(1);
+            metric["ClassicPageUncustomizedHomePageCount"].Should().Be(1);
+
+            // Readiness — only the three pages with web parts contribute
+            metric["ClassicPagePagesWithWebPartsCount"].Should().Be(3);
+            metric["ClassicPageMappableWebPartPagesCount"].Should().Be(1);   // b (100%)
+            metric["ClassicPageUnmappedWebPartPagesCount"].Should().Be(2);   // a (75), c (50)
+            metric["ClassicPageAvgMappingPercentage"].Should().BeApproximately(75.0, 0.0001); // (75+100+50)/3
+
+            // Web part inventory
+            metric["ClassicPageWebPartCount"].Should().Be(5);
+            metric["ClassicPageUniqueWebPartTypeCount"].Should().Be(3);
+            metric["ClassicPageMappableWebPartTypeCount"].Should().Be(2);
+            metric["ClassicPageUnmappedWebPartTypeCount"].Should().Be(1);
+        }
+
+        [Fact]
+        public void Telemetry_LogPageScan_EmptyScan_AllZero()
+        {
+            using var fixture = new ScanContextFixture();
+
+            var metric = new Dictionary<string, double>();
+            using (var context = fixture.CreateContext())
+            {
+                TelemetryManager.BuildClassicMetrics(context, metric);
+            }
+
+            // Every metric key is emitted (so the schema is stable) and every value is zero —
+            // including the average, which divides-by-zero-safe to 0 when no page carries web parts.
+            metric.Values.Should().OnlyContain(v => v == 0);
+            metric.Should().ContainKey("ClassicPageCount");
+            metric.Should().ContainKey("ClassicPageAvgMappingPercentage");
+            metric["ClassicPageAvgMappingPercentage"].Should().Be(0);
+        }
+
+        private static ClassicPage NewPage(Guid scanId, string siteUrl, string pageUrl, string pageType,
+                                           int webPartCount, double mappingPercentage,
+                                           bool homePage = false, bool uncustomizedHomePage = false)
+        {
+            return new ClassicPage
+            {
+                ScanId = scanId,
+                SiteUrl = siteUrl,
+                WebUrl = "/",
+                PageUrl = pageUrl,
+                PageName = Path.GetFileName(pageUrl),
+                PageType = pageType,
+                WebPartCount = webPartCount,
+                MappingPercentage = mappingPercentage,
+                HomePage = homePage,
+                UncustomizedHomePage = uncustomizedHomePage,
+            };
+        }
+
+        private static ClassicPageWebPart NewWebPart(Guid scanId, string siteUrl, string pageUrl, int index, string type)
+        {
+            return new ClassicPageWebPart
+            {
+                ScanId = scanId,
+                SiteUrl = siteUrl,
+                WebUrl = "/",
+                PageUrl = pageUrl,
+                WebPartIndex = index,
+                WebPartType = type,
+                WebPartTypeShort = type.Split('.').Last(),
+            };
+        }
+    }
+}

--- a/src/PnP.Scanning/PnP.Scanning.Core/Services/TelemetryManager.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Services/TelemetryManager.cs
@@ -198,6 +198,10 @@ namespace PnP.Scanning.Core.Services
                 {
                     await PopulateAlertsMetricsAsync(scanId, metrics);
                 }
+                else if (Scan.CLIMode.Equals(Mode.Classic.ToString()))
+                {
+                    await PopulateClassicMetricsAsync(scanId, metrics);
+                }
 
                 // Send the event
                 telemetryClient.TrackEvent($"{Scan.CLIMode}{TelemetryEvent.Done}", properties, metrics);
@@ -236,6 +240,126 @@ namespace PnP.Scanning.Core.Services
                 metric.Add("FailedWebCount", failedWebCount);
                 metric.Add("ScanDurationInMinutes", scanDurationInMinutes);
             }
+        }
+
+        private async Task PopulateClassicMetricsAsync(Guid scanId, Dictionary<string, double> metric)
+        {
+            using (var dbContext = await StorageManager.GetScanContextForDataExportAsync(scanId))
+            {
+                BuildClassicMetrics(dbContext, metric);
+            }
+        }
+
+        /// <summary>
+        /// T14 — builds the classic page-scan telemetry payload (page type distribution + page
+        /// transformation readiness) from the scan's stored page inventory. Pure over the
+        /// <see cref="ScanContext"/> (no network, no scan-status gating) so it can be unit-tested
+        /// against the in-memory SQLite fixture — same testability split as the storage/export cores.
+        /// </summary>
+        internal static void BuildClassicMetrics(ScanContext dbContext, Dictionary<string, double> metric)
+        {
+            // Page type distribution (the DB only holds classic pages — modern pages are not persisted).
+            int pageCount = 0;
+            int wikiPageCount = 0;
+            int webPartPageCount = 0;
+            int aspxPageCount = 0;
+            int publishingPageCount = 0;
+            int blogPageCount = 0;
+            int delveBlogPageCount = 0;
+
+            int homePageCount = 0;
+            int uncustomizedHomePageCount = 0;
+
+            // Page transformation readiness — only pages that actually carry web parts contribute to
+            // the mapping metrics (empty pages are 100% by the T6 convention and would mask real readiness).
+            int pagesWithWebParts = 0;
+            int mappableWebPartPages = 0;   // fully mappable (MappingPercentage >= 100)
+            int unmappedWebPartPages = 0;   // partially/not mappable (< 100)
+            double mappingPercentageSum = 0;
+
+            foreach (var page in dbContext.ClassicPages)
+            {
+                pageCount++;
+
+                switch (page.PageType)
+                {
+                    case PageScanComponent.WikiPage: wikiPageCount++; break;
+                    case PageScanComponent.WebPartPage: webPartPageCount++; break;
+                    case PageScanComponent.ASPXPage: aspxPageCount++; break;
+                    case PageScanComponent.PublishingPage: publishingPageCount++; break;
+                    case PageScanComponent.BlogPage: blogPageCount++; break;
+                    case PageScanComponent.DelveBlogPage: delveBlogPageCount++; break;
+                }
+
+                if (page.HomePage)
+                {
+                    homePageCount++;
+                }
+
+                if (page.UncustomizedHomePage)
+                {
+                    uncustomizedHomePageCount++;
+                }
+
+                if (page.WebPartCount > 0)
+                {
+                    pagesWithWebParts++;
+                    mappingPercentageSum += page.MappingPercentage;
+
+                    if (page.MappingPercentage >= 100)
+                    {
+                        mappableWebPartPages++;
+                    }
+                    else
+                    {
+                        unmappedWebPartPages++;
+                    }
+                }
+            }
+
+            int webPartCount = 0;
+            foreach (var webPart in dbContext.ClassicPageWebParts)
+            {
+                webPartCount++;
+            }
+
+            // Scan-wide unique web part inventory (one row per distinct type, see T9).
+            int uniqueWebPartTypeCount = 0;
+            int mappableWebPartTypeCount = 0;
+            int unmappedWebPartTypeCount = 0;
+            foreach (var unique in dbContext.ClassicWebPartUniques)
+            {
+                uniqueWebPartTypeCount++;
+                if (unique.InMappingFile)
+                {
+                    mappableWebPartTypeCount++;
+                }
+                else
+                {
+                    unmappedWebPartTypeCount++;
+                }
+            }
+
+            metric.Add("ClassicPageCount", pageCount);
+            metric.Add("ClassicPageWikiCount", wikiPageCount);
+            metric.Add("ClassicPageWebPartPageCount", webPartPageCount);
+            metric.Add("ClassicPageASPXCount", aspxPageCount);
+            metric.Add("ClassicPagePublishingCount", publishingPageCount);
+            metric.Add("ClassicPageBlogCount", blogPageCount);
+            metric.Add("ClassicPageDelveBlogCount", delveBlogPageCount);
+
+            metric.Add("ClassicPageHomePageCount", homePageCount);
+            metric.Add("ClassicPageUncustomizedHomePageCount", uncustomizedHomePageCount);
+
+            metric.Add("ClassicPagePagesWithWebPartsCount", pagesWithWebParts);
+            metric.Add("ClassicPageMappableWebPartPagesCount", mappableWebPartPages);
+            metric.Add("ClassicPageUnmappedWebPartPagesCount", unmappedWebPartPages);
+            metric.Add("ClassicPageAvgMappingPercentage", pagesWithWebParts > 0 ? mappingPercentageSum / pagesWithWebParts : 0);
+
+            metric.Add("ClassicPageWebPartCount", webPartCount);
+            metric.Add("ClassicPageUniqueWebPartTypeCount", uniqueWebPartTypeCount);
+            metric.Add("ClassicPageMappableWebPartTypeCount", mappableWebPartTypeCount);
+            metric.Add("ClassicPageUnmappedWebPartTypeCount", unmappedWebPartTypeCount);
         }
 
         private async Task PopulateAddInsACSMetricsAsync(Guid scanId, Dictionary<string, double> metric)


### PR DESCRIPTION
## What

Adds classic page-scan telemetry to the Microsoft 365 Assessment tool's `Classic`
scan mode. Until now `Mode.Classic` had no telemetry populator, so a classic page
scan emitted only the generic site-collection/web counts — the page inventory and
transformation-readiness signals (the capability ported from the old Modernization
Scanner) were not reported.

Implements **T14** of the classic-page-scan backlog. P4 / optional, out of strict
parity scope — net-new insight into how the ported page scan is used in the field.

## How

Telemetry in this engine is not per-component log methods: `TelemetryManager.LogScanEndAsync`
owns the single `{Mode}Done` event and switches on `Scan.CLIMode` to call a
`Populate{Mode}MetricsAsync` populator (Workflow / InfoPath / AddInsACS / Alerts).
`Mode.Classic` simply had no branch. This PR follows that existing pattern rather
than inventing a new public log API:

- **`TelemetryManager.cs`**
  - New `Mode.Classic` branch in the `LogScanEndAsync` switch (after Alerts), so the
    classic metrics ride the existing `ClassicDone` event alongside the generic ones.
  - `PopulateClassicMetricsAsync(scanId, metric)` opens the scan DB and delegates to
    a new `internal static void BuildClassicMetrics(ScanContext, Dictionary<string,double>)`
    — the pure, network-free payload builder. Same testability split as the existing
    storage/export/rewrite cores (T8/T9/T11/T12).
  - Metrics emitted (all `ClassicPage`-prefixed):
    - **Page type distribution:** `ClassicPageCount` + per-type
      `Wiki/WebPartPage/ASPX/Publishing/Blog/DelveBlog` counts.
    - **Home pages:** `HomePageCount`, `UncustomizedHomePageCount`.
    - **Transformation readiness:** `PagesWithWebPartsCount`,
      `MappableWebPartPagesCount` (≥100%), `UnmappedWebPartPagesCount` (<100%),
      `AvgMappingPercentage` (mean over pages-with-web-parts, div-by-zero-safe to 0 —
      same empty-page convention as T6/T9).
    - **Web part inventory:** `WebPartCount` + scan-wide unique-type counts
      (`UniqueWebPartTypeCount`, `MappableWebPartTypeCount`, `UnmappedWebPartTypeCount`).
  - Every key is always emitted (stable schema), even for an empty scan.

No new migration or schema — reads the existing T5–T10 page columns and the T9 unique
web-part inventory.

## Tests

`Tests/Services/TelemetryManagerTests.cs` (new, 2):
- `Telemetry_LogPageScan_BuildsExpectedPayload` — one page per classic type, three
  carrying web parts (75 / 100 / 50); asserts every metric incl. the avg (75) and the
  mappable/unmapped partition.
- `Telemetry_LogPageScan_EmptyScan_AllZero` — empty DB → all keys present, all values 0.