### PR TITLE
Enable Classic mode assessment (classic page scan) and document it

### DIFF
--- a/docs/classic/assess.md
+++ b/docs/classic/assess.md
@@ -1,0 +1,49 @@
+# Run a classic pages assessment
+
+Running the classic pages assessment is just like running any other module of the Microsoft 365 Assessment tool: you use the CLI with the `Start` action to launch an assessment. By specifying the `--mode` to be `Classic` (and including the `Pages` component) the Microsoft 365 Assessment tool will run the classic pages assessment for you. This page provides you with a quick start and links to the relevant Microsoft 365 Assessment tool documentation for more details.
+
+> [!IMPORTANT]
+> The classic pages assessment is **pre-release** — runnable from a development build but not yet part of a shipped release. The samples below show the intended usage. Within a Classic assessment the Azure ACS and SharePoint Add-Ins components are skipped (they are provided by the dedicated [`--mode AddInsACS`](../addinsacs/readme.md) module).
+
+## Quick start
+
+### Download the Microsoft 365 Assessment tool
+
+The Microsoft 365 Assessment tool must first be downloaded from https://github.com/pnp/pnpassessment/releases. More details can be found in the [download](../using-the-assessment-tool/download.md) documentation.
+
+### Ensure you've an Entra application setup
+
+The Microsoft 365 Assessment tool requires an Entra application for authenticating to SharePoint. More details in the [authentication](../using-the-assessment-tool/setupauth.md) documentation.
+
+### Start assessment
+
+Below are some quick start samples that show how to run a classic pages assessment. More details on the `Start` action can be found in the [Microsoft 365 Assessment tool Start documentation](../using-the-assessment-tool/assess-start.md).
+
+Task | CLI
+-----|------
+Start a new classic pages assessment (application permissions) for a complete tenant | microsoft365-assessment.exe start --mode Classic --classicinclude Pages --authmode application <br> --tenant bertonline.sharepoint.com --applicationid c545f9ce-1c11-440b-812b-0b35217d9e83 <br> --certpath "My&#124;CurrentUser&#124;b133d1cb4d19ce539986c7ac67de005481084c84"
+Start a classic pages assessment for a set of site collections | microsoft365-assessment.exe start --mode Classic --classicinclude Pages --authmode interactive <br> --tenant bertonline.sharepoint.com --applicationid c545f9ce-1c11-440b-812b-0b35217d9e83 <br> --siteslist "https://bertonline.sharepoint.com/sites/ussales,https://bertonline.sharepoint.com/sites/europesales"
+Assess only the home page of each web, exporting web part properties | microsoft365-assessment.exe start --mode Classic --classicinclude Pages --homepageonly --exportwebpartproperties <br> --authmode application --tenant bertonline.sharepoint.com --applicationid c545f9ce-1c11-440b-812b-0b35217d9e83 <br> --certpath "My&#124;CurrentUser&#124;b133d1cb4d19ce539986c7ac67de005481084c84"
+
+See the [requirements](requirements.md) page for the full list of classic page-scan arguments (`--exportwebpartproperties`, `--skipusageinformation`, `--skipuserinformation`, `--homepageonly`).
+
+### Live status updates
+
+Once an assessment is launched you'd typically followup on it's status via the `Status` action. Below is a quick start, more details can be found in the [Microsoft 365 Assessment tool operations documentation](../using-the-assessment-tool/assess-operations.md#getting-a-live-status-overview-of-a-running-assessment).
+
+Task | CLI
+-----|------
+Realtime status update of the running assessments | microsoft365-assessment.exe status
+
+### Generate report
+
+When an assessment has finished you can continue with the next step and that's generating the Power BI report by using the `Report` action. Below is a quick start, more details can be found in the [Microsoft 365 Assessment tool Report documentation](../using-the-assessment-tool/assess-report.md).
+
+Task | CLI
+-----|------
+Generate Power BI report (includes CSV export) in the default location | microsoft365-assessment.exe report --id 22989c75-f08f-4af9-8857-6f19e333d6d3
+Export the gathered data as CSV files in a custom location | microsoft365-assessment.exe report --id 22989c75-f08f-4af9-8857-6f19e333d6d3 <br> --mode CsvOnly --path "c:\reports"
+
+[!INCLUDE [Clarify the --id parameter](./../fragments/clarify-id-parameter.md)]
+
+To better understand the generated Power BI report and accompanying CSV files use the nodes in the left navigation.

--- a/docs/classic/csv-classicpages.md
+++ b/docs/classic/csv-classicpages.md
@@ -1,0 +1,34 @@
+# classicpages.csv file details
+
+## Summary
+
+This csv file contains one row for every classic page (wiki, web part, publishing, blog or ASPX page) that was discovered and assessed, including its page-modernization-readiness columns.
+
+## Columns
+
+The following columns are included:
+
+Column|Description
+------|-----------
+PageUrl | Server-relative URL of the page
+PageName | Display name of the page
+PageType | The detected classic page type: `WikiPage`, `WebPartPage`, `PublishingPage`, `BlogPage`, `ASPXPage` or `DelveBlogPage`
+ListUrl | Server-relative URL of the library the page lives in
+ListTitle | Title of the library the page lives in
+ListId | Id of the library the page lives in
+ModifiedAt | When the page was last modified
+Layout | The detected page layout (e.g. a wiki `TwoColumns`, a web part page `FullPageVertical`, or the publishing page layout name such as `ArticleLeft`)
+HomePage | True when this page is the web's home (welcome) page
+UncustomizedHomePage | True when this home page is still the default, uncustomized home page (only meaningful when `HomePage` is true)
+ModifiedBy | Display name of the user who last modified the page (empty when `--skipuserinformation` was specified)
+ViewsRecent | Recent page views (empty/zero when `--skipusageinformation` was specified)
+ViewsRecentUniqueUsers | Unique users for the recent page views
+ViewsLifeTime | Lifetime page views
+ViewsLifeTimeUniqueUsers | Unique users for the lifetime page views
+WebPartCount | Number of web parts found on the page
+MappingPercentage | Percentage (0-100) of the page's web parts that have a known modern mapping. A page with no web parts is reported as 100%
+UnmappedWebParts | Comma-separated list of the (short) web part type names on the page that do not have a known modern mapping
+RemediationCode | The remediation code for this page type (`CP1`-`CP5`)
+ScanId | Id of the assessment
+SiteUrl | Fully qualified site collection URL
+WebUrl | Relative URL of this web

--- a/docs/classic/csv-classicpagewebparts.md
+++ b/docs/classic/csv-classicpagewebparts.md
@@ -1,0 +1,28 @@
+# classicpagewebparts.csv file details
+
+## Summary
+
+This csv file contains one row for every web part found on the assessed classic pages. It is the detailed inventory behind the `WebPartCount` / `MappingPercentage` columns of [classicpages.csv](csv-classicpages.md).
+
+## Columns
+
+The following columns are included:
+
+Column|Description
+------|-----------
+PageUrl | Server-relative URL of the page the web part is on
+WebPartIndex | Zero-based index of the web part within the page (document order)
+WebPartType | The fully qualified web part type name
+WebPartTypeShort | The short (class) name of the web part type
+WebPartTitle | The web part's title
+WebPartProperties | The web part's properties serialized as JSON (only populated when `--exportwebpartproperties` was specified)
+ZoneId | The id of the web part zone the web part is in (web part / publishing pages)
+Row | The row the web part is placed in
+Column | The column the web part is placed in
+Order | The order of the web part within its zone / cell
+Hidden | True when the web part is hidden
+IsClosed | True when the web part is closed
+IsMappable | True when this web part type has a known modern mapping (i.e. it is present in the web part mapping model)
+ScanId | Id of the assessment
+SiteUrl | Fully qualified site collection URL
+WebUrl | Relative URL of this web

--- a/docs/classic/csv-classicsitesummaries.md
+++ b/docs/classic/csv-classicsitesummaries.md
@@ -1,0 +1,29 @@
+# classicsitesummaries.csv file details
+
+## Summary
+
+This csv file contains one row per assessed site collection with roll-up information. It is shared by all classic assessment components; this page documents the columns relevant to the classic **pages** assessment (page counts and page-modernization-readiness roll-ups, aggregated from all webs in the site collection). The page-readiness columns are computed only over pages that actually carry web parts.
+
+## Columns
+
+The following page-relevant columns are included (the file also contains roll-up columns for the other classic components such as lists, workflows and add-ins):
+
+Column|Description
+------|-----------
+RootWebTemplate | The template of the site collection's root web
+SubWebCount | Number of sub webs in the site collection
+ClassicPages | Total number of classic pages found across the site collection
+ClassicWikiPages | Number of classic wiki pages
+ClassicASPXPages | Number of classic ASPX pages
+ClassicBlogPages | Number of classic blog pages
+ClassicWebPartPages | Number of classic web part pages
+ClassicPublishingPages | Number of classic publishing pages
+ModernPages | Number of modern pages found across the site collection
+PagesWithWebParts | Number of classic pages that carry at least one web part
+MappableWebPartPages | Number of pages (with web parts) whose web parts are fully mappable (mapping percentage of 100)
+UnmappedWebPartPages | Number of pages (with web parts) that have at least one unmapped web part (mapping percentage below 100)
+AvgMappingPercentage | The average mapping percentage across the pages that carry web parts
+UncustomizedHomePages | Number of uncustomized (default) home pages found across the site collection
+AggregatedRemediationCodes | The aggregated remediation codes for the site collection
+ScanId | Id of the assessment
+SiteUrl | Fully qualified site collection URL

--- a/docs/classic/csv-classicwebpartunique.md
+++ b/docs/classic/csv-classicwebpartunique.md
@@ -1,0 +1,18 @@
+# classicwebpartunique.csv file details
+
+## Summary
+
+This csv file contains one row for every unique web part type encountered across the whole assessment, together with whether that type is known to the modern web part mapping model and on how many pages it was found. It is useful to quickly understand which web part types are driving your unmapped (not-yet-modernizable) pages.
+
+## Columns
+
+The following columns are included:
+
+Column|Description
+------|-----------
+WebPartType | The fully qualified web part type name
+InMappingFile | True when this web part type is present in the web part mapping model (i.e. it has a known modern mapping)
+PageCount | The number of distinct pages this web part type was found on
+ScanId | Id of the assessment
+SiteUrl | Fully qualified site collection URL
+WebUrl | Relative URL of this web

--- a/docs/classic/csv-classicwebsummaries.md
+++ b/docs/classic/csv-classicwebsummaries.md
@@ -1,0 +1,29 @@
+# classicwebsummaries.csv file details
+
+## Summary
+
+This csv file contains one row per assessed web with roll-up information. It is shared by all classic assessment components; this page documents the columns relevant to the classic **pages** assessment (page counts and page-modernization-readiness roll-ups). The page-readiness columns are computed only over pages that actually carry web parts.
+
+## Columns
+
+The following page-relevant columns are included (the file also contains roll-up columns for the other classic components such as lists, workflows and add-ins):
+
+Column|Description
+------|-----------
+Template | The web template
+ClassicPages | Total number of classic pages found in this web
+ClassicWikiPages | Number of classic wiki pages
+ClassicASPXPages | Number of classic ASPX pages
+ClassicBlogPages | Number of classic blog pages
+ClassicWebPartPages | Number of classic web part pages
+ClassicPublishingPages | Number of classic publishing pages
+ModernPages | Number of modern pages found in this web
+PagesWithWebParts | Number of classic pages that carry at least one web part
+MappableWebPartPages | Number of pages (with web parts) whose web parts are fully mappable (mapping percentage of 100)
+UnmappedWebPartPages | Number of pages (with web parts) that have at least one unmapped web part (mapping percentage below 100)
+AvgMappingPercentage | The average mapping percentage across the pages that carry web parts
+UncustomizedHomePages | Number of uncustomized (default) home pages found in this web
+AggregatedRemediationCodes | The aggregated remediation codes for this web
+ScanId | Id of the assessment
+SiteUrl | Fully qualified site collection URL
+WebUrl | Relative URL of this web

--- a/docs/classic/readme.md
+++ b/docs/classic/readme.md
@@ -1,0 +1,17 @@
+# Classic SharePoint Pages Assessment
+
+Modern SharePoint pages are the recommended, supported way to build pages in SharePoint Online. Many tenants still contain **classic** pages — wiki pages, web part pages and publishing pages — that predate the modern page experience. The classic pages assessment helps you understand where classic pages live in your tenant and how ready those pages are to be modernized: for each classic page it inventories the web parts on the page and calculates a **mapping percentage** that indicates how many of those web parts have a modern equivalent.
+
+This module carries the classic page scanning capability of the older [SharePoint Modernization Scanner](https://aka.ms/sharepoint/modernization/scanner) forward into the Microsoft 365 Assessment tool, so you can use a single, supported tool for this assessment.
+
+The assessment provides you with:
+
+- A per-page inventory of the classic pages found (page type, layout, home-page flags, last modified, usage) — see [classicpages.csv](csv-classicpages.md).
+- A per-web-part inventory of every web part found on those pages — see [classicpagewebparts.csv](csv-classicpagewebparts.md).
+- A tenant-wide inventory of the unique web part types encountered and whether each is known to the modern mapping model — see [classicwebpartunique.csv](csv-classicwebpartunique.md).
+- Web- and site-level [readiness roll-ups](csv-classicwebsummaries.md) and a [Power BI report](report-intro.md) to visualize the results.
+
+> [!IMPORTANT]
+> The classic pages assessment is **pre-release**: it is implemented, tested and runnable from a development build via `start --mode Classic --classicinclude Pages`, but is not yet part of a shipped release. Within a Classic assessment only the implemented components run (Pages, Lists, Workflow, InfoPath, Extensibility) — the Azure ACS and SharePoint Add-Ins assessments are provided by the dedicated [`--mode AddInsACS`](../addinsacs/readme.md) module. Track availability via the [releases](https://github.com/pnp/pnpassessment/releases) page.
+
+Use the left navigation to learn how to [run the assessment](assess.md), the [requirements](requirements.md), and the details of the generated report and CSV files.

--- a/docs/classic/report-intro.md
+++ b/docs/classic/report-intro.md
@@ -1,0 +1,17 @@
+# The Power BI report
+
+The generated report is a Power BI report and can be opened in Power BI Desktop (see https://aka.ms/pbidesktopstore to install Power BI Desktop).
+
+When using the report from Power BI Desktop there are some things to understand:
+
+- The report is built using multiple pages, use the bottom tabs to switch to different report pages. The **Classic Page Readiness** page summarizes how ready your classic pages are to be modernized (distribution of pages by mapping percentage, the most common unmapped web parts, and the overall web part inventory).
+- When the report is opened from the generated Power BI pbit file it's not saved, meaning if you close Power BI Desktop it will ask you to save the file. You can also save the opened report yourselves using the **save** icon top left; when saving as a Power BI pbix file the data and report are combined into a single file, making it easier for you to move around and share the report.
+- If you want to update the visualizations used you can use the toolbar and visualizations and fields sections at the right.
+
+The report is driven by the exported CSV files. Even if you do not use Power BI, the CSV files contain the full assessment data — use the left navigation to learn more about each one:
+
+- [classicpages.csv](csv-classicpages.md) — one row per classic page, including its modernization-readiness columns.
+- [classicpagewebparts.csv](csv-classicpagewebparts.md) — one row per web part found on a classic page.
+- [classicwebpartunique.csv](csv-classicwebpartunique.md) — one row per unique web part type encountered across the assessment.
+- [classicwebsummaries.csv](csv-classicwebsummaries.md) — per-web readiness roll-up.
+- [classicsitesummaries.csv](csv-classicsitesummaries.md) — per-site-collection readiness roll-up.

--- a/docs/classic/requirements.md
+++ b/docs/classic/requirements.md
@@ -1,0 +1,30 @@
+# Requirements
+
+This page lists the classic pages assessment specific requirements and options.
+
+## Permission requirements
+
+When using the classic pages module of the Microsoft 365 Assessment tool you do need to use a configured Entra application ([learn more here](../using-the-assessment-tool/setupauth.md)). The classic pages assessment reads page content and web part configuration via CSOM and queries SharePoint search for page usage, so it needs read access to the assessed sites.
+
+Authentication | Minimal
+---------------| -------
+Application | **Graph:** Sites.Read.All <br> **SharePoint:** Sites.FullControl.All
+Delegated | **Graph:** Sites.Read.All, User.Read <br> **SharePoint:** AllSites.FullControl
+
+> [!Note]
+> `Sites.FullControl.All` is requested because reading a classic web part page's web part inventory via the `LimitedWebPartManager` API requires more than read-only access. If a future release can lower this requirement it will be reflected here.
+
+## Command line arguments for starting an assessment
+
+The classic pages assessment is selected with `--mode Classic` and the `--classicinclude Pages` component. The following page-scan specific arguments are available (they are only valid together with `--mode Classic`):
+
+Argument | Description
+---------|------------
+`--classicinclude Pages` | Include the classic page scan in a classic assessment. When `--classicinclude` is omitted all classic components are included.
+`--exportwebpartproperties` | Also export each web part's properties (as JSON) into the per-web-part inventory. Off by default to keep the export compact.
+`--skipusageinformation` | Skip collecting page usage information (recent / lifetime views and their unique users) via SharePoint search. Use this to speed up the assessment or when search-based usage is not needed.
+`--skipuserinformation` | Skip collecting page user information (e.g. the page's *Modified By*).
+`--homepageonly` | Only assess the home page of each web, rather than every classic page. Useful for a fast home-page modernization-readiness assessment.
+
+> [!Note]
+> To learn more about starting an assessment checkout the Microsoft 365 Assessment tool [Start documentation](../using-the-assessment-tool/assess-start.md).

--- a/docs/classic/toc.yml
+++ b/docs/classic/toc.yml
@@ -1,0 +1,20 @@
+- name: Introduction
+  href: readme.md
+- name: Requirements
+  href: requirements.md
+- name: Run an assessment
+  href: assess.md
+- name: Report
+  href: report-intro.md
+- name: CSV files
+  items:
+    - name: classicpages.csv
+      href: csv-classicpages.md
+    - name: classicpagewebparts.csv
+      href: csv-classicpagewebparts.md
+    - name: classicwebpartunique.csv
+      href: csv-classicwebpartunique.md
+    - name: classicwebsummaries.csv
+      href: csv-classicwebsummaries.md
+    - name: classicsitesummaries.csv
+      href: csv-classicsitesummaries.md

--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -1,0 +1,28 @@
+# Running the tests
+
+The engine (`PnP.Scanning`) has a unit test project, `PnP.Scanning.Core.Tests` (xUnit). The tests are pure unit tests that run offline with no external dependencies.
+
+## Unit tests
+
+From `src/PnP.Scanning`:
+
+```powershell
+dotnet test PnP.Scanning.Core.Tests/PnP.Scanning.Core.Tests.csproj
+```
+
+For the classic pages assessment, the unit tests cover the pure sub-logic (wiki/HTML parsing, web part mapping, layout detection, home-page detection, usage-row parsing, the storage and CSV-export cores, etc.).
+
+## End-to-end validation
+
+The SharePoint CSOM code paths that cannot be unit-tested in isolation — reading a page's web parts via the `LimitedWebPartManager`, reading `Web.CanModernizeHomepage`, and the page-usage search query — are validated by running an actual assessment against a test tenant with the CLI:
+
+```powershell
+microsoft365-assessment.exe start --mode Classic --classicinclude Pages `
+  --authmode application --tenant contoso.sharepoint.com `
+  --applicationid <app-id> --certfile <path-to-cert.pfx> `
+  --siteslist "https://contoso.sharepoint.com/sites/team"
+
+microsoft365-assessment.exe report --id <assessment-id> --mode CsvOnly --path "c:\reports"
+```
+
+Inspect the exported `classicpages.csv`, `classicpagewebparts.csv`, `classicwebpartunique.csv` and the web/site summaries to confirm the assessment produced the expected data. See [Run a classic pages assessment](../classic/assess.md) for the full set of options.

--- a/docs/contributing/toc.yml
+++ b/docs/contributing/toc.yml
@@ -1,2 +1,4 @@
 - name: Getting started
   href: readme.md
+- name: Running the tests
+  href: running-tests.md

--- a/docs/fragments/supportedassessments.md
+++ b/docs/fragments/supportedassessments.md
@@ -5,3 +5,4 @@ Module | Type | Mode parameter | Description
 [InfoPath Forms Services](./../infopath/readme.md) | Retirement | InfoPath | Helps you assess your tenant to understand where you're using InfoPath Forms Services and how upgradable those to alternative solutions. **Available as of version 1.5.0**
 [SharePoint Add-Ins and Azure ACS](./../addinsacs/readme.md) | Retirement | AddInsACS | Helps you assess your tenant to understand where you're using SharePoint Add-Ins and Azure ACS principals. **Available as of version 1.6.0**
 [SharePoint Alerts](./../alerts/readme.md) | Retirement | Alerts | Helps you assess your tenant to understand where you're using SharePoint Alerts. **Available as of version 1.11.0**
+[Classic Pages](./../classic/readme.md) | Modernization | Classic | Helps you assess your tenant to understand where you're using classic SharePoint pages and how ready those pages are to be modernized. **In development**

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -10,5 +10,7 @@
   href: addinsacs/
 - name: Alerts
   href: alerts/
+- name: Classic Pages
+  href: classic/
 - name: Contributing
   href: contributing/

--- a/src/PnP.Scanning/PnP.Scanning.Process/Commands/Handlers/StartCommandHandler.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Process/Commands/Handlers/StartCommandHandler.cs
@@ -400,14 +400,6 @@ namespace PnP.Scanning.Process.Commands
 
         private async Task HandleStartAsync(StartOptions arguments)
         {
-            // temporary block for classic assessment run as it's not yet done
-            if (arguments.Mode == Mode.Classic)
-            {
-                AnsiConsole.MarkupLine($"[red]Classic mode is not yet implemented[/]");
-                AnsiConsole.MarkupLine("");
-                return;
-            }
-
             // Auto populate the tenant id when not provided
             if (string.IsNullOrEmpty(arguments.TenantId) && !string.IsNullOrEmpty(arguments.Tenant))
             {
@@ -515,16 +507,35 @@ namespace PnP.Scanning.Process.Commands
 
                 if (arguments.Mode == Mode.Classic)
                 {
-                    List<ClassicComponent> classicComponents = new();
+                    List<ClassicComponent> classicComponents;
                     if (arguments.ClassicInclude.Count > 0)
                     {
                         // Only add the requested classic scan components
-                        classicComponents = arguments.ClassicInclude;
+                        classicComponents = new List<ClassicComponent>(arguments.ClassicInclude);
                     }
                     else
                     {
                         // Add all possible classic scan components
                         classicComponents = Enum.GetValues(typeof(ClassicComponent)).Cast<ClassicComponent>().ToList();
+                    }
+
+                    // The Azure ACS and SharePoint Add-Ins components are not (yet) implemented as part of a
+                    // Classic assessment; they are covered by the dedicated --mode AddInsACS assessment. Drop
+                    // them so a Classic assessment never silently produces empty data for them, warning when a
+                    // user explicitly requested them via --classicinclude.
+                    foreach (var component in new[] { ClassicComponent.AzureACS, ClassicComponent.SharePointAddIns })
+                    {
+                        if (classicComponents.Remove(component) && arguments.ClassicInclude.Count > 0)
+                        {
+                            AnsiConsole.MarkupLine($"[yellow]The '{component}' component is not available in a Classic assessment; use --mode AddInsACS instead. Skipping it.[/]");
+                        }
+                    }
+
+                    if (classicComponents.Count == 0)
+                    {
+                        AnsiConsole.MarkupLine($"[red]No supported classic scan components were selected. Supported components: Workflow, InfoPath, Pages, Lists, Extensibility.[/]");
+                        AnsiConsole.MarkupLine("");
+                        return;
                     }
 
                     ClassicStartRequestBuilder.AddClassicProperties(


### PR DESCRIPTION
## What

Opens up the **Classic** assessment mode for end users. Until now `--mode Classic`
was hard-blocked with a "Classic mode is not yet implemented" message; with the
classic page scan work (T1–T15) merged, this removes the gate and ships the
supporting user docs.

## Changes

**`StartCommandHandler.cs`**
- Remove the temporary early-return that blocked every `--mode Classic` run.
- Filter out the `AzureACS` and `SharePointAddIns` components from a Classic run —
  these are covered by the dedicated `--mode AddInsACS` assessment and would
  otherwise silently produce empty data. When a user explicitly requests them via
  `--classicinclude`, a yellow warning is shown instead of dropping them silently.
- Bail out with a clear error if component filtering leaves nothing to scan
  (supported components: `Workflow`, `InfoPath`, `Pages`, `Lists`, `Extensibility`).
- Copy `--classicinclude` into a fresh list rather than mutating the parsed
  arguments in place.

**Docs**
- New `docs/classic/` section: assessment guide, requirements, report intro, and
  CSV column references (`classicpages`, `classicpagewebparts`, `classicsitesummaries`,
  `classicwebpartunique`, `classicwebsummaries`), plus TOC wiring.
- Add `docs/contributing/running-tests.md` and TOC entry.
- List Classic under supported assessments (`docs/fragments/supportedassessments.md`).

## Why

The `PnP.Scanning` engine now carries the classic page scanning capability ported
from the legacy SharePoint Modernization Scanner, so the mode is ready to expose.
Filtering ACS/Add-Ins keeps the Classic assessment from reporting empty data for
components that live in a different mode.

## Testing

- `--mode Classic --classicinclude Pages` end-to-end run against a test tenant.
- Verified the warning path (`--classicinclude AzureACS`) and the empty-selection
  error path.