### PR TITLE
Fix classicwebpartunique InMappingFile defect + register classic docs in docfx

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -15,6 +15,8 @@
           "addinsacs/toc.yml",
           "alerts/**.md",
           "alerts/toc.yml",
+          "classic/**.md",
+          "classic/toc.yml",
           "contributing/**.md",
           "contributing/toc.yml",
           "toc.yml",

--- a/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/ClassicPageRollupTests.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core.Tests/Storage/ClassicPageRollupTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
 using PnP.Scanning.Core.Storage;
 using PnP.Scanning.Core.Tests.Fixtures;
 using Xunit;
@@ -74,6 +75,12 @@ namespace PnP.Scanning.Core.Tests.Storage
             }
         }
 
+        // Assembly-qualified web part types — InMappingFile is resolved against the real embedded
+        // webpartmapping.xml, so these must be the actual keys the mapping file uses.
+        private const string ContentEditorType = "Microsoft.SharePoint.WebPartPages.ContentEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string ScriptEditorType = "Microsoft.SharePoint.WebPartPages.ScriptEditorWebPart, Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c";
+        private const string CustomType = "Contoso.Custom.WebParts.MyCustomWebPart, Contoso.Custom, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0000000000000000";
+
         [Fact]
         public async Task Rollup_WebPartUnique_AggregatesPageCounts()
         {
@@ -82,12 +89,17 @@ namespace PnP.Scanning.Core.Tests.Storage
 
             // ContentEditor appears twice on page A (counts the page once) and once on page B -> 2 pages.
             // A custom (non-mapped) web part appears once on page A -> 1 page.
+            // ScriptEditor is the regression guard for the InMappingFile defect: it is present in
+            // webpartmapping.xml (InMappingFile=true) but has no <Mappings> (IsMappable=false). The unique
+            // row's InMappingFile must reflect *presence in the file*, not the row's IsMappable flag — so
+            // even though the seeded row carries IsMappable=false, InMappingFile must come out true.
             var webParts = new List<ClassicPageWebPart>
             {
-                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 0, type: "ContentEditorWebPart", isMappable: true),
-                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 1, type: "ContentEditorWebPart", isMappable: true),
-                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 2, type: "Contoso.Custom.WebPart", isMappable: false),
-                NewWebPart(scanId, siteUrl, "/", "/Pages/b.aspx", index: 0, type: "ContentEditorWebPart", isMappable: true),
+                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 0, type: ContentEditorType, isMappable: true),
+                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 1, type: ContentEditorType, isMappable: true),
+                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 2, type: CustomType, isMappable: false),
+                NewWebPart(scanId, siteUrl, "/", "/Pages/a.aspx", index: 3, type: ScriptEditorType, isMappable: false),
+                NewWebPart(scanId, siteUrl, "/", "/Pages/b.aspx", index: 0, type: ContentEditorType, isMappable: true),
             };
 
             using (var context = fixture.CreateContext())
@@ -95,7 +107,7 @@ namespace PnP.Scanning.Core.Tests.Storage
                 await context.ClassicPageWebParts.AddRangeAsync(webParts);
                 await context.SaveChangesAsync();
 
-                await StorageManager.PopulateWebPartUniqueAsync(context, scanId);
+                await StorageManager.PopulateWebPartUniqueAsync(context, scanId, new WebPartMappingManager());
             }
 
             using (var context = fixture.CreateContext())
@@ -104,15 +116,20 @@ namespace PnP.Scanning.Core.Tests.Storage
                     .Where(u => u.ScanId == scanId)
                     .ToList();
 
-                uniques.Should().HaveCount(2);
+                uniques.Should().HaveCount(3);
 
-                var contentEditor = uniques.Single(u => u.WebPartType == "ContentEditorWebPart");
+                var contentEditor = uniques.Single(u => u.WebPartType == ContentEditorType);
                 contentEditor.InMappingFile.Should().BeTrue();
                 contentEditor.PageCount.Should().Be(2);
 
-                var custom = uniques.Single(u => u.WebPartType == "Contoso.Custom.WebPart");
+                var custom = uniques.Single(u => u.WebPartType == CustomType);
                 custom.InMappingFile.Should().BeFalse();
                 custom.PageCount.Should().Be(1);
+
+                // Listed-but-unmapped: present in the file -> InMappingFile true, despite IsMappable=false.
+                var scriptEditor = uniques.Single(u => u.WebPartType == ScriptEditorType);
+                scriptEditor.InMappingFile.Should().BeTrue();
+                scriptEditor.PageCount.Should().Be(1);
             }
         }
 

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/ClassicScanner.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/ClassicScanner.cs
@@ -184,7 +184,7 @@ namespace PnP.Scanning.Core.Scanners
                 // transformation readiness up into its ClassicWebSummary and build the scan-wide unique
                 // web part inventory. The site loop below then reads the now-populated web columns.
                 await StorageManager.ComputeAndStoreWebPageRollupsAsync(dbContext, ScanId);
-                await StorageManager.PopulateWebPartUniqueAsync(dbContext, ScanId);
+                await StorageManager.PopulateWebPartUniqueAsync(dbContext, ScanId, PageScanComponent.MappingManager);
 
                 // Roll the publishing webs + pages up into one per-site-collection publishing-portal line
                 // (parity with the legacy ModernizationPublishingSiteScanResults.csv). Reads the web summaries

--- a/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Scanners/Classic/PageScanComponent.cs
@@ -22,8 +22,9 @@ namespace PnP.Scanning.Core.Scanners
 
         // The web part mapping model (embedded webpartmapping.xml) is read-only after construction, so a
         // single shared instance is reused across webs/threads instead of re-parsing the ~1370-line file
-        // for every web.
-        private static readonly WebPartMappingManager MappingManager = new();
+        // for every web. Also reused by the post-scan unique-web-part rollup (StorageManager.
+        // PopulateWebPartUniqueAsync) so it shares the same parsed mapping file.
+        internal static readonly WebPartMappingManager MappingManager = new();
 
         // Fields
         private const string FileRefField = "FileRef";

--- a/src/PnP.Scanning/PnP.Scanning.Core/Storage/StorageManager.cs
+++ b/src/PnP.Scanning/PnP.Scanning.Core/Storage/StorageManager.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using PnP.Core;
 using PnP.Core.Services;
 using PnP.Scanning.Core.Scanners;
+using PnP.Scanning.Core.Scanners.WebPartMapping;
 using PnP.Scanning.Core.Services;
 using Serilog;
 
@@ -1013,14 +1014,17 @@ namespace PnP.Scanning.Core.Storage
 
         // T9: build the scan-wide unique web part inventory (mirrors the old scanner's UniqueWebParts.csv,
         // plus a page count). One ClassicWebPartUnique row per distinct WebPartType seen anywhere in the scan.
-        //   InMappingFile = the type exists in webpartmapping.xml — taken from the IsMappable flag T6 stamped
-        //                   on every ClassicPageWebPart row (all rows of a given type share the same value).
+        //   InMappingFile = the type is present in webpartmapping.xml at all (presence check), matching the
+        //                   legacy UniqueWebParts.csv column. This is deliberately NOT the IsMappable flag:
+        //                   IsMappable is present AND has a <Mappings> element, so a listed-but-unmapped type
+        //                   (e.g. ScriptEditor/SimpleForm) is InMappingFile=true but IsMappable=false. Resolved
+        //                   via the same shared WebPartMappingManager the page scan uses.
         //   PageCount     = number of distinct classic pages that reference the type at least once.
-        internal static async Task PopulateWebPartUniqueAsync(ScanContext dbContext, Guid scanId)
+        internal static async Task PopulateWebPartUniqueAsync(ScanContext dbContext, Guid scanId, WebPartMappingManager mappingManager)
         {
             var rows = await dbContext.ClassicPageWebParts
                 .Where(wp => wp.ScanId == scanId)
-                .Select(wp => new { wp.WebPartType, wp.IsMappable, wp.SiteUrl, wp.WebUrl, wp.PageUrl })
+                .Select(wp => new { wp.WebPartType, wp.SiteUrl, wp.WebUrl, wp.PageUrl })
                 .ToListAsync();
 
             var uniques = rows
@@ -1029,7 +1033,7 @@ namespace PnP.Scanning.Core.Storage
                 {
                     ScanId = scanId,
                     WebPartType = g.Key,
-                    InMappingFile = g.Any(wp => wp.IsMappable),
+                    InMappingFile = mappingManager.InMappingFile(g.Key),
                     PageCount = g.Select(wp => (wp.SiteUrl, wp.WebUrl, wp.PageUrl)).Distinct().Count(),
                 })
                 .ToList();


### PR DESCRIPTION
## What

Two independent fixes surfaced by the T16 cross-tool parity audit of the classic
page scan.

### 1. `classicwebpartunique.csv` — `InMappingFile` computed incorrectly

`StorageManager.PopulateWebPartUniqueAsync` computed the per-type `InMappingFile`
column as `g.Any(wp => wp.IsMappable)`. `IsMappable` means *present in
webpartmapping.xml **and** has a `<Mappings>` element*, whereas `InMappingFile`
should mean *present in the file at all*. This flipped the verdict for
listed-but-unmapped types (e.g. `ScriptEditorWebPart`, `SimpleFormWebPart`),
contradicting the tool's own per-page `IsMappable` and diverging from the legacy
Modernization Scanner's `UniqueWebParts.csv` (which uses a presence check,
`found != null`).

**Fix:** call `WebPartMappingManager.InMappingFile(g.Key)` — a presence-only
`ContainsKey` check. The shared `PageScanComponent.MappingManager` singleton
(promoted `private` → `internal`) is threaded into the post-scan rollup, so the
~1370-line mapping file is not re-parsed.

### 2. Docs build (`docfx`) fails with `--warningsAsErrors`

The `docs/classic/` folder (files, `toc.yml`, and inbound links from the root
`toc.yml`, `contributing/running-tests.md`, and `fragments/supportedassessments.md`)
was added without registering the folder in `docfx.json`. docfx validates links
against the content set, so it emitted 4 warnings (missing `classic/toc.yml`;
invalid links to `~/classic/assess.md` / `~/classic/readme.md`), and `build.ps1`
runs with `--warningsAsErrors`, failing the job.

**Fix:** add `classic/**.md` + `classic/toc.yml` to `docfx.json` content globs,
matching every other module.

## Testing

- **Unit:** `ClassicPageRollupTests.Rollup_WebPartUnique_AggregatesPageCounts`
  rewritten to use real assembly-qualified type keys and a **`ScriptEditor`
  regression guard** — a seeded row with `IsMappable=false` must still yield
  `InMappingFile=true`. Full suite green (**130 passed, 0 failed**).
- **Docs:** `docfx build ./docfx.json --warningsAsErrors` now reports
  **0 warnings, 0 errors** (exit 0).

## Files

- `Storage/StorageManager.cs` — presence-check fix + threaded mapping manager
- `Scanners/Classic/PageScanComponent.cs` — singleton `private` → `internal`
- `Scanners/Classic/ClassicScanner.cs` — pass the manager to the rollup
- `Tests/Storage/ClassicPageRollupTests.cs` — real type keys + ScriptEditor guard
- `docs/docfx.json` — register the `classic/` docs folder