### PR TITLE
docs: mark classic pages assessment as GA in v1.15.0

### DIFF
--- a/docs/classic/assess.md
+++ b/docs/classic/assess.md
@@ -2,8 +2,8 @@
 
 Running the classic pages assessment is just like running any other module of the Microsoft 365 Assessment tool: you use the CLI with the `Start` action to launch an assessment. By specifying the `--mode` to be `Classic` (and including the `Pages` component) the Microsoft 365 Assessment tool will run the classic pages assessment for you. This page provides you with a quick start and links to the relevant Microsoft 365 Assessment tool documentation for more details.
 
-> [!IMPORTANT]
-> The classic pages assessment is **pre-release** — runnable from a development build but not yet part of a shipped release. The samples below show the intended usage. Within a Classic assessment the Azure ACS and SharePoint Add-Ins components are skipped (they are provided by the dedicated [`--mode AddInsACS`](../addinsacs/readme.md) module).
+> [!NOTE]
+> The classic pages assessment is available as of **version 1.15.0** of the Microsoft 365 Assessment tool. Within a Classic assessment the Azure ACS and SharePoint Add-Ins components are skipped (they are provided by the dedicated [`--mode AddInsACS`](../addinsacs/readme.md) module).
 
 ## Quick start
 

--- a/docs/classic/readme.md
+++ b/docs/classic/readme.md
@@ -11,7 +11,7 @@ The assessment provides you with:
 - A tenant-wide inventory of the unique web part types encountered and whether each is known to the modern mapping model — see [classicwebpartunique.csv](csv-classicwebpartunique.md).
 - Web- and site-level [readiness roll-ups](csv-classicwebsummaries.md) and a [Power BI report](report-intro.md) to visualize the results.
 
-> [!IMPORTANT]
-> The classic pages assessment is **pre-release**: it is implemented, tested and runnable from a development build via `start --mode Classic --classicinclude Pages`, but is not yet part of a shipped release. Within a Classic assessment only the implemented components run (Pages, Lists, Workflow, InfoPath, Extensibility) — the Azure ACS and SharePoint Add-Ins assessments are provided by the dedicated [`--mode AddInsACS`](../addinsacs/readme.md) module. Track availability via the [releases](https://github.com/pnp/pnpassessment/releases) page.
+> [!NOTE]
+> The classic pages assessment is available as of **version 1.15.0** of the Microsoft 365 Assessment tool — [download the latest release](https://github.com/pnp/pnpassessment/releases) to get started. Within a Classic assessment only the classic components run (Pages, Lists, Workflow, InfoPath, Extensibility); the Azure ACS and SharePoint Add-Ins assessments are provided by the dedicated [`--mode AddInsACS`](../addinsacs/readme.md) module.
 
 Use the left navigation to learn how to [run the assessment](assess.md), the [requirements](requirements.md), and the details of the generated report and CSV files.

--- a/docs/fragments/supportedassessments.md
+++ b/docs/fragments/supportedassessments.md
@@ -5,4 +5,4 @@ Module | Type | Mode parameter | Description
 [InfoPath Forms Services](./../infopath/readme.md) | Retirement | InfoPath | Helps you assess your tenant to understand where you're using InfoPath Forms Services and how upgradable those to alternative solutions. **Available as of version 1.5.0**
 [SharePoint Add-Ins and Azure ACS](./../addinsacs/readme.md) | Retirement | AddInsACS | Helps you assess your tenant to understand where you're using SharePoint Add-Ins and Azure ACS principals. **Available as of version 1.6.0**
 [SharePoint Alerts](./../alerts/readme.md) | Retirement | Alerts | Helps you assess your tenant to understand where you're using SharePoint Alerts. **Available as of version 1.11.0**
-[Classic Pages](./../classic/readme.md) | Modernization | Classic | Helps you assess your tenant to understand where you're using classic SharePoint pages and how ready those pages are to be modernized. **In development**
+[Classic Pages](./../classic/readme.md) | Modernization | Classic | Helps you assess your tenant to understand where you're using classic SharePoint pages and how ready those pages are to be modernized. **Available as of version 1.15.0**


### PR DESCRIPTION
The classic pages assessment shipped in v1.15.0, so drop the "pre-release / in development" framing from the docs:

- supportedassessments.md: "In development" -> "Available as of version 1.15.0"
- classic/readme.md and classic/assess.md: replace the pre-release IMPORTANT callouts with release-availability notes