### PR TITLE
docs: sync site index with v1.15.0 classic page wording

### DIFF
--- a/docs/fragments/supportedassessments.md
+++ b/docs/fragments/supportedassessments.md
@@ -1,7 +1,7 @@
 
 Module | Type | Mode parameter | Description
 -------|------|----------------|------------
+[Classic Pages](./../classic/readme.md) | Modernization | Classic | Helps you assess your tenant to understand where you're using classic pages (Web Part, Wiki, Blog and Publishing pages) and how ready they are for modernization. For each page it inventories the web parts, computes a modernization readiness percentage and the list of unmapped web parts, detects the page layout, flags home pages and uncustomized home pages, and captures usage statistics — rolling the results up into per-web and per-site-collection summaries. **Available as of version 1.15.0**
 [InfoPath Forms Services](./../infopath/readme.md) | Retirement | InfoPath | Helps you assess your tenant to understand where you're using InfoPath Forms Services and how upgradable those to alternative solutions. **Available as of version 1.5.0**
 [SharePoint Add-Ins and Azure ACS](./../addinsacs/readme.md) | Retirement | AddInsACS | Helps you assess your tenant to understand where you're using SharePoint Add-Ins and Azure ACS principals. **Available as of version 1.6.0**
 [SharePoint Alerts](./../alerts/readme.md) | Retirement | Alerts | Helps you assess your tenant to understand where you're using SharePoint Alerts. **Available as of version 1.11.0**
-[Classic Pages](./../classic/readme.md) | Modernization | Classic | Helps you assess your tenant to understand where you're using classic SharePoint pages and how ready those pages are to be modernized. **Available as of version 1.15.0**

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The Microsoft 365 Assessment tool in an open-source tool maintained by Microsoft
 
 ## Relationship with the "Modernization Scanner" ❓
 
-Over time the Microsoft 365 Assessment tool replaces the relevant [Modernization Scanner](https://aka.ms/sharepoint/modernization/scanner) modules. As of version 1.15.0 the classic page scanning / page transformation readiness capability — previously only available in the [Modernization Scanner](https://aka.ms/sharepoint/modernization/scanner) — has been carried over into the Microsoft 365 Assessment tool, so the Modernization Scanner is no longer needed for that scenario. The [Modernization Scanner](https://aka.ms/sharepoint/modernization/scanner) should only be used if a needed module is not yet available as part of the Microsoft 365 Assessment tool.
+As of version 1.15.0 the Microsoft 365 Assessment tool supports the **full classic page scan functionality** of the [Modernization Scanner](https://aka.ms/sharepoint/modernization/scanner) — classic page discovery and typing (Web Part, Wiki, Blog and Publishing pages), live web-part extraction, modernization readiness scoring, page-layout detection, usage statistics, and the per-web / per-site-collection summaries. The ported capability has been validated field-for-field against the legacy scanner on a live tenant across all four classic page types, with **significantly better performance and scale**. The [Modernization Scanner](https://aka.ms/sharepoint/modernization/scanner) should only be used if a needed module is not yet available as part of the Microsoft 365 Assessment tool.
 
 ## Community rocks, sharing is caring 💖
 


### PR DESCRIPTION
## Summary

The published docs site (`pnp.github.io/pnpassessment`) is built from `docs/` via DocFX, not from `README.md`, and the two had drifted. This aligns the site's homepage and module table with the v1.15.0 classic-page wording already in `README.md`.

## Changes

- **`docs/index.md`** — replaced the older/softer "Relationship with the Modernization Scanner" section with the v1.15.0 wording (full classic page scan functionality, validated field-for-field, significantly better performance and scale).
- **`docs/fragments/supportedassessments.md`** — expanded the Classic Pages description (web-part inventory, readiness %, unmapped parts, layout detection, home-page flags, usage stats, per-web / per-site rollups) and moved **Classic Pages to the top** of the module table.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)